### PR TITLE
feat: 시큐리티 초기 설정

### DIFF
--- a/src/main/java/com/budgetguard/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/budgetguard/global/config/security/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.budgetguard.global.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+import com.budgetguard.global.config.security.handler.CustomAccessDeniedHandler;
+import com.budgetguard.global.config.security.handler.CustomAuthenticationEntryPoint;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final CustomAccessDeniedHandler accessDeniedHandler;
+	private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		return http
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.csrf(AbstractHttpConfigurer::disable)
+			.cors(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+
+			// 기본 세션을 사용하지 않도록 설정
+			.sessionManagement(session ->
+				session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+			.authorizeHttpRequests(request ->
+				request.requestMatchers(
+					"/api/v1/auth/**"
+				).permitAll())
+			.authorizeHttpRequests(request ->
+				request.anyRequest().authenticated())
+
+			.exceptionHandling(e -> e.accessDeniedHandler(accessDeniedHandler)) // 권한 없이 접근
+			.exceptionHandling(e -> e.authenticationEntryPoint(authenticationEntryPoint)) // 유효하지 않은 자격으로 접근
+
+			.build();
+	}
+}

--- a/src/main/java/com/budgetguard/global/config/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/budgetguard/global/config/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package com.budgetguard.global.config.security.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.budgetguard.global.error.ErrorCode;
+import com.budgetguard.global.format.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final ObjectMapper mapper;
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException {
+
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType("application/json; charset=UTF-8");
+
+		ApiResponse body = ApiResponse.toFailForm(ErrorCode.ACCESS_DENIED.getMessage());
+
+		response.getWriter().write(mapper.writeValueAsString(body));
+	}
+}

--- a/src/main/java/com/budgetguard/global/config/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/budgetguard/global/config/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.budgetguard.global.config.security.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.budgetguard.global.error.ErrorCode;
+import com.budgetguard.global.format.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper mapper;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException {
+
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.setContentType("application/json; charset=UTF-8");
+
+		ApiResponse body = ApiResponse.toFailForm(ErrorCode.UNAUTHORIZED_ENTRY_POINT.getMessage());
+
+		response.getWriter().write(mapper.writeValueAsString(body));
+	}
+}

--- a/src/main/java/com/budgetguard/global/error/ErrorCode.java
+++ b/src/main/java/com/budgetguard/global/error/ErrorCode.java
@@ -12,7 +12,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-	EXAMPLE_ERROR("예시 에러", HttpStatus.BAD_REQUEST);
+	ACCESS_DENIED("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+	UNAUTHORIZED_ENTRY_POINT("유효하지 않은 자격 증명입니다.", HttpStatus.UNAUTHORIZED);
 
 	private final String message;
 	private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🔥 Related Issue

close: #3 

## 📝 Description

* jwt 인증에 불필요한 httpBasic, csrf, cors, formLogin을 비활성화했습니다.
* 스프링 시큐리티의 기본 세션을 사용하지 않도록 했습니다.
* 회원가입, 로그인 등이 포함되는 `/api/v1/auth/**`를 제외한 요청은 인증이 필요하도록 설정했습니다.
* 예외 핸들러를 설정하여 ApiResponse 형태로 예외 응답이 발생하도록 설정했습니다.