### PR TITLE
Feature/#5 사용자 회원 가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.5'
 	id 'io.spring.dependency-management' version '1.1.3'
+	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com'
@@ -12,6 +13,7 @@ java {
 }
 
 configurations {
+	asciidoctorExt // html 자동 변경 사용 설정
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -19,6 +21,10 @@ configurations {
 
 repositories {
 	mavenCentral()
+}
+
+ext {
+	set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencies {
@@ -41,14 +47,51 @@ dependencies {
 	annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 	annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
+	// .adocs를 html로 자동 변화
+	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.named('asciidoctor') {
+	inputs.dir snippetsDir
+	dependsOn test
+	configurations 'asciidoctorExt' // html 자동 변경 사용
+	baseDirFollowsSourceFile() // .adoc 파일에서 다른.adoc 파일을 include하여 사용할 때 경로를 동일하게 baseDir로 설정
+}
+
+asciidoctor.doFirst {
+	delete file('src/main/resources/static/docs') //실행 전 이전 html 삭제
+}
+
+// build/docs/asciidoc 에 생성된 html 문서를 src/main/resources/static/docs 에 복사해온다.
+task createDocument(type: Copy) {
+	dependsOn asciidoctor // asciidoctor 후 실행
+
+	from file("build/docs/asciidoc")
+	into file("src/main/resources/static")
+}
+
+//jar의 static/docs에 문서 복사
+bootJar {
+	dependsOn createDocument
+
+	from("${asciidoctor.outputDir}") {
+		into 'static/docs'
+	}
+}
+
+//빌드전 createDocument 실행
+build {
+	dependsOn createDocument
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,72 @@
+= BudgetGuard API 명세
+:doctype: book
+:icons: front
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+:docinfo: shared-head
+
+[[overview]]
+= 개요
+
+[[overview-http-verbs]]
+== HTTP 동사
+
+본 REST API에서 사용하는 HTTP 동사(verbs)는 가능한한 표준 HTTP와 REST 규약을 따릅니다.
+
+|===
+| 동사 | 용례
+
+| `GET`
+| 리소스를 가져올 때 사용
+
+| `POST`
+| 새 리소스를 만들 때 사용
+
+| `PUT`
+| 기존 리소스를 수정할 때 사용
+
+| `PATCH`
+| 기존 리소스의 일부를 수정할 때 사용
+
+| `DELETE`
+| 기존 리소스를 삭제할 떄 사용
+|===
+
+== Response API JSON
+
+```json
+//성공
+{
+    "status" : "success",
+    "message" : null,
+    "data" : { data }
+}
+
+//일반 에러
+{
+    "status" : "fail",
+    "message" : "fail message",
+    "data" : null
+}
+
+//예외 발생
+{
+    "status" : "error",
+    "message" : "error message",
+    "data" : null
+}
+```
+
+== 예외 메시지 형식
+
+```json
+{
+  "status" : "error",
+  "message" : "[{오류값}] {오류필드}: {오류메시지}.",
+  "data" : null
+}
+```
+
+include::member.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -1,0 +1,19 @@
+== 회원
+
+=== 회원 가입
+
+Request
+
+include::{snippets}/signup/회원_가입_성공/http-request.adoc[]
+
+Response
+
+- 201 Created
+
+include::{snippets}/signup/회원_가입_성공/http-response.adoc[]
+
+- 400 BadRequest
+
+include::{snippets}/signup/비밀번호와_비밀번호_확인이_일치하지_않으면_실패/http-response.adoc[]
+
+include::{snippets}/signup/이미_사용중인_계정명이면_실패/http-response.adoc[]

--- a/src/main/java/com/budgetguard/domain/auth/api/AuthController.java
+++ b/src/main/java/com/budgetguard/domain/auth/api/AuthController.java
@@ -1,0 +1,39 @@
+package com.budgetguard.domain.auth.api;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.budgetguard.domain.auth.application.AuthService;
+import com.budgetguard.domain.member.dto.request.MemberSignupRequestParam;
+import com.budgetguard.global.format.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	/**
+	 * 회원 가입
+	 *
+	 * @param param 회원 가입 입력 데이터
+	 * @return 201, 생성된 회원의 ID
+	 */
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResponse> signup(@RequestBody @Validated MemberSignupRequestParam param) {
+		param.isValidPassword();
+
+		Long memberId = authService.signup(param);
+		return ResponseEntity.status(CREATED)
+			.body(ApiResponse.toSuccessForm(memberId));
+	}
+}

--- a/src/main/java/com/budgetguard/domain/auth/application/AuthService.java
+++ b/src/main/java/com/budgetguard/domain/auth/application/AuthService.java
@@ -1,0 +1,46 @@
+package com.budgetguard.domain.auth.application;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.budgetguard.domain.member.dao.MemberRepository;
+import com.budgetguard.domain.member.dto.request.MemberSignupRequestParam;
+import com.budgetguard.domain.member.entity.Member;
+import com.budgetguard.global.error.BusinessException;
+import com.budgetguard.global.error.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	/**
+	 * 회원 가입
+	 *
+	 * @param param 회원 가입 입력 데이터
+	 * @return 생성된 회원의 id
+	 */
+	public Long signup(MemberSignupRequestParam param) {
+		checkDuplicatedAccount(param.getAccount());
+
+		Member member = param.toEntity(passwordEncoder);
+		Member savedMember = memberRepository.save(member);
+		return savedMember.getId();
+	}
+
+	/**
+	 * 회원 아이디 중복 확인
+	 * 중복이면 예외 처리
+	 *
+	 * @param account 확인할 회원 아이디
+	 */
+	private void checkDuplicatedAccount(String account) {
+		if (memberRepository.findByAccount(account).isPresent()) {
+			throw new BusinessException(account, "account", ErrorCode.DUPLICATED_ACCOUNT);
+		}
+	}
+}

--- a/src/main/java/com/budgetguard/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/budgetguard/domain/member/dao/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.budgetguard.domain.member.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.budgetguard.domain.member.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	Optional<Member> findByAccount(String account);
+}

--- a/src/main/java/com/budgetguard/domain/member/dto/request/MemberSignupRequestParam.java
+++ b/src/main/java/com/budgetguard/domain/member/dto/request/MemberSignupRequestParam.java
@@ -1,0 +1,60 @@
+package com.budgetguard.domain.member.dto.request;
+
+import org.hibernate.validator.constraints.Length;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.budgetguard.domain.member.entity.Member;
+import com.budgetguard.global.error.BusinessException;
+import com.budgetguard.global.error.ErrorCode;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberSignupRequestParam {
+
+	private static final int MIN_ACCOUNT_LENGTH = 6;
+	private static final int MAX_ACCOUNT_LENGTH = 20;
+
+	// 대소문자와 특수문자로 구성된 8~16 자리의 문자
+	private static final String PASSWORD_REGEX_PATTERN = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,16}$";
+
+	@NotEmpty(message = "계정명을 입력해주세요.")
+	@Length(min = MIN_ACCOUNT_LENGTH, max = MAX_ACCOUNT_LENGTH, message = "계정명을 {min} ~ {max} 사이로 입력해주세요.")
+	private String account;
+
+	@NotEmpty(message = "비밀번호를 입력해주세요.")
+	@Pattern(regexp = PASSWORD_REGEX_PATTERN, message = "비밀번호는 특수문자를 포함한 8~16 자리의 문자여야 합니다.")
+	private String password;
+
+	@NotEmpty(message = "비밀번호 확인을 입력해주세요.")
+	@Pattern(regexp = PASSWORD_REGEX_PATTERN, message = "비밀번호는 특수문자를 포함한 8~16 자리의 문자여야 합니다.")
+	private String passwordConfirm;
+
+	@Builder
+	private MemberSignupRequestParam(String account, String password, String passwordConfirm) {
+		this.account = account;
+		this.password = password;
+		this.passwordConfirm = passwordConfirm;
+	}
+
+	/**
+	 * 비밀번호와 비밀번호 확인이 일치하지 않으면 예외 처리
+	 */
+	public void isValidPassword() {
+		if (!password.equals(passwordConfirm)) {
+			throw new BusinessException(password, "password", ErrorCode.INVALID_PASSWORD_CONFIRM);
+		}
+	}
+
+	public Member toEntity(PasswordEncoder passwordEncoder) {
+		return Member.builder()
+				.account(account)
+				.password(passwordEncoder.encode(password))
+				.build();
+	}
+}

--- a/src/main/java/com/budgetguard/domain/member/entity/Member.java
+++ b/src/main/java/com/budgetguard/domain/member/entity/Member.java
@@ -1,0 +1,35 @@
+package com.budgetguard.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private String account;
+
+	@Column(nullable = false)
+	private String password;
+
+	@Builder
+	private Member(Long id, String account, String password) {
+		this.id = id;
+		this.account = account;
+		this.password = password;
+	}
+}

--- a/src/main/java/com/budgetguard/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/budgetguard/global/config/security/SecurityConfig.java
@@ -6,6 +6,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import com.budgetguard.global.config.security.handler.CustomAccessDeniedHandler;
@@ -44,5 +46,10 @@ public class SecurityConfig {
 			.exceptionHandling(e -> e.authenticationEntryPoint(authenticationEntryPoint)) // 유효하지 않은 자격으로 접근
 
 			.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
 	}
 }

--- a/src/main/java/com/budgetguard/global/error/ErrorCode.java
+++ b/src/main/java/com/budgetguard/global/error/ErrorCode.java
@@ -12,6 +12,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+	// 회원가입
+	INVALID_PASSWORD_CONFIRM("비밀번호와 비밀번호 확인이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+	DUPLICATED_ACCOUNT("이미 사용중인 계정명입니다.", HttpStatus.BAD_REQUEST),
+
+	// 인가 인증
 	ACCESS_DENIED("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
 	UNAUTHORIZED_ENTRY_POINT("유효하지 않은 자격 증명입니다.", HttpStatus.UNAUTHORIZED);
 

--- a/src/main/java/com/budgetguard/global/error/GlobalExceptionAdvice.java
+++ b/src/main/java/com/budgetguard/global/error/GlobalExceptionAdvice.java
@@ -17,6 +17,9 @@ public class GlobalExceptionAdvice {
 
 	/**
 	 * 바인딩 예외 처리
+	 *
+	 * @param e 바인딩 예외
+	 * @return 400, 바인딩 예외 메세지
 	 */
 	@ExceptionHandler(BindException.class)
 	public ResponseEntity<ApiResponse> bindException(BindException e) {
@@ -34,6 +37,9 @@ public class GlobalExceptionAdvice {
 
 	/**
 	 * 비즈니스 로직 예외 처리
+	 *
+	 * @param e 비즈니스 로직 예외
+	 * @return 비즈니스 로직 예외 메세지
 	 */
 	@ExceptionHandler(BusinessException.class)
 	public ResponseEntity<ApiResponse> businessException(BusinessException e) {
@@ -43,6 +49,14 @@ public class GlobalExceptionAdvice {
 			.body(ApiResponse.toFailForm(failMessage));
 	}
 
+	/**
+	 * 잘못된 값이 들어왔을 때 메세지 생성
+	 *
+	 * @param invalidValue 잘못된 값
+	 * @param fieldName   필드 이름
+	 * @param message    예외 메세지
+	 * @return 메세지
+	 */
 	private String createFailMessage(String invalidValue, String fieldName, String message) {
 		return String.format("[%s] 필드에서 잘못된 값 [%s]를 받았습니다. (%s)", fieldName, invalidValue, message);
 	}

--- a/src/test/java/com/budgetguard/config/restdocs/AbstractRestDocsTest.java
+++ b/src/test/java/com/budgetguard/config/restdocs/AbstractRestDocsTest.java
@@ -1,0 +1,42 @@
+package com.budgetguard.config.restdocs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+/**
+ * mockMvc를 사용할 때, 자동으로 rest docs가 작성된다.
+ */
+@Import(RestDocsConfiguration.class)
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class AbstractRestDocsTest {
+
+	@Autowired
+	protected RestDocumentationResultHandler restDocs;
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp(
+		final WebApplicationContext context,
+		final RestDocumentationContextProvider restDocumentation) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.apply(documentationConfiguration(restDocumentation))
+			.alwaysDo(MockMvcResultHandlers.print())
+			.alwaysDo(restDocs)
+			.addFilters(new CharacterEncodingFilter("UTF-8", true))
+			.build();
+	}
+}

--- a/src/test/java/com/budgetguard/config/restdocs/RestDocsConfiguration.java
+++ b/src/test/java/com/budgetguard/config/restdocs/RestDocsConfiguration.java
@@ -1,0 +1,23 @@
+package com.budgetguard.config.restdocs;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+/**
+ * rest docs의 가독성을 높인다.
+ */
+@TestConfiguration
+public class RestDocsConfiguration {
+
+	@Bean
+	public RestDocumentationResultHandler write() {
+		return MockMvcRestDocumentation.document(
+			"{class-name}/{method-name}", // identifier
+			Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+			Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+		);
+	}
+}

--- a/src/test/java/com/budgetguard/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/budgetguard/domain/auth/api/AuthControllerTest.java
@@ -1,0 +1,97 @@
+package com.budgetguard.domain.auth.api;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.budgetguard.domain.auth.application.AuthService;
+import com.budgetguard.domain.member.MemberTestHelper;
+import com.budgetguard.domain.member.dto.request.MemberSignupRequestParam;
+import com.budgetguard.domain.member.entity.Member;
+import com.budgetguard.global.error.BusinessException;
+import com.budgetguard.global.error.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+	static final String URL = "/api/v1/auth";
+	static final Member member = MemberTestHelper.createMember();
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper mapper;
+
+	@MockBean
+	AuthService authService;
+
+	@BeforeEach
+	void setUp(WebApplicationContext context) {
+		mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+	}
+
+	@Nested
+	@DisplayName("회원 가입")
+	class signup {
+		@Test
+		@DisplayName("회원 가입 성공")
+		void 회원_가입_성공() throws Exception {
+			MemberSignupRequestParam param = MemberSignupRequestParam.builder()
+				.account(member.getAccount())
+				.password(member.getPassword())
+				.passwordConfirm(member.getPassword())
+				.build();
+
+			given(authService.signup(any())).willReturn(1L);
+
+			mockMvc.perform(post(URL + "/signup")
+				.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(param)))
+				.andExpect(status().isCreated());
+		}
+
+		@Test
+		@DisplayName("비밀번호와 비밀번호 확인이 일치하지않으면 실패")
+		void 비밀번호와_비밀번호_확인이_일치하지않으면_실패() throws Exception {
+			String wrongPasswordConfirm = "wrong";
+			MemberSignupRequestParam param = MemberSignupRequestParam.builder()
+				.account(member.getAccount())
+				.password(member.getPassword())
+				.passwordConfirm(wrongPasswordConfirm)
+				.build();
+
+			mockMvc.perform(post(URL + "/signup")
+					.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(param)))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("이미 사용중인 계정명이면 실패")
+		void 이미_사용중인_계정명이면_실패() throws Exception {
+			MemberSignupRequestParam param = MemberSignupRequestParam.builder()
+				.account(member.getAccount())
+				.password(member.getPassword())
+				.passwordConfirm(member.getPassword())
+				.build();
+
+			given(authService.signup(any())).willThrow(new BusinessException(member.getAccount(), "account", ErrorCode.DUPLICATED_ACCOUNT));
+
+			mockMvc.perform(post(URL + "/signup")
+					.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(param)))
+				.andExpect(status().isBadRequest());
+		}
+	}
+}

--- a/src/test/java/com/budgetguard/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/budgetguard/domain/auth/api/AuthControllerTest.java
@@ -5,17 +5,14 @@ import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 
+import com.budgetguard.config.restdocs.AbstractRestDocsTest;
 import com.budgetguard.domain.auth.application.AuthService;
 import com.budgetguard.domain.member.MemberTestHelper;
 import com.budgetguard.domain.member.dto.request.MemberSignupRequestParam;
@@ -25,24 +22,16 @@ import com.budgetguard.global.error.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(AuthController.class)
-class AuthControllerTest {
+class AuthControllerTest extends AbstractRestDocsTest {
 
 	static final String URL = "/api/v1/auth";
 	static final Member member = MemberTestHelper.createMember();
-
-	@Autowired
-	MockMvc mockMvc;
 
 	@Autowired
 	ObjectMapper mapper;
 
 	@MockBean
 	AuthService authService;
-
-	@BeforeEach
-	void setUp(WebApplicationContext context) {
-		mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
-	}
 
 	@Nested
 	@DisplayName("회원 가입")

--- a/src/test/java/com/budgetguard/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/budgetguard/domain/auth/api/AuthControllerTest.java
@@ -53,8 +53,8 @@ class AuthControllerTest extends AbstractRestDocsTest {
 		}
 
 		@Test
-		@DisplayName("비밀번호와 비밀번호 확인이 일치하지않으면 실패")
-		void 비밀번호와_비밀번호_확인이_일치하지않으면_실패() throws Exception {
+		@DisplayName("비밀번호와 비밀번호 확인이 일치하지 않으면 실패")
+		void 비밀번호와_비밀번호_확인이_일치하지_않으면_실패() throws Exception {
 			String wrongPasswordConfirm = "wrong";
 			MemberSignupRequestParam param = MemberSignupRequestParam.builder()
 				.account(member.getAccount())

--- a/src/test/java/com/budgetguard/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/budgetguard/domain/auth/application/AuthServiceTest.java
@@ -1,0 +1,72 @@
+package com.budgetguard.domain.auth.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.budgetguard.domain.member.MemberTestHelper;
+import com.budgetguard.domain.member.dao.MemberRepository;
+import com.budgetguard.domain.member.dto.request.MemberSignupRequestParam;
+import com.budgetguard.domain.member.entity.Member;
+import com.budgetguard.global.error.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+	static final Member member = MemberTestHelper.createMember();
+
+	@InjectMocks
+	AuthService authService;
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@Mock
+	PasswordEncoder passwordEncoder;
+
+	@Nested
+	@DisplayName("회원 가입")
+	class signup {
+		@Test
+		@DisplayName("회원 가입 성공")
+		void 회원_가입_성공() {
+			MemberSignupRequestParam param = MemberSignupRequestParam.builder()
+				.account(member.getAccount())
+				.password(member.getPassword())
+				.passwordConfirm(member.getPassword())
+				.build();
+
+			given(memberRepository.findByAccount(any())).willReturn(Optional.empty());
+			given(memberRepository.save(any())).willReturn(member);
+
+			Long memberId = authService.signup(param);
+
+			assertThat(memberId).isEqualTo(member.getId());
+		}
+
+		@Test
+		@DisplayName("이미 사용중인 계정명이면 실패")
+		void 이미_사용중인_계정명이면_실패() {
+			MemberSignupRequestParam param = MemberSignupRequestParam.builder()
+				.account(member.getAccount())
+				.password(member.getPassword())
+				.passwordConfirm(member.getPassword())
+				.build();
+
+			given(memberRepository.findByAccount(any())).willReturn(Optional.of(member));
+
+			assertThrows(BusinessException.class, () -> authService.signup(param));
+		}
+	}
+}

--- a/src/test/java/com/budgetguard/domain/member/MemberTestHelper.java
+++ b/src/test/java/com/budgetguard/domain/member/MemberTestHelper.java
@@ -1,0 +1,17 @@
+package com.budgetguard.domain.member;
+
+import com.budgetguard.domain.member.entity.Member;
+
+/**
+ * 테스트용 Member 객체를 생성해주는 클래스
+ */
+public class MemberTestHelper {
+
+	public static Member createMember() {
+		return Member.builder()
+			.id(1L)
+			.account("testAccount")
+			.password("Password123!")
+			.build();
+	}
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #5 

## 📝 Description

* 아이디, 비밀번호, 비밀번호 확인을 요청 파라미터로 받아서 회원가입을 진행합니다.
* 비밀번호와 비밀번호 확인이 일치하지 않으면 예외가 발생합니다.
* 이미 사용중인 아이디면 예외가 발생합니다.
* RestDocsTest를 적용하여 자동으로 API 명세서를 작성합니다.
