### PR TITLE
Feature/#7 JWT 로그인 및 로그아웃 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -37,34 +37,27 @@
 == Response API JSON
 
 ```json
-//성공
+// 성공
 {
     "status" : "success",
     "message" : null,
     "data" : { data }
 }
 
-//일반 에러
+// 실패
 {
     "status" : "fail",
     "message" : "fail message",
     "data" : null
 }
-
-//예외 발생
-{
-    "status" : "error",
-    "message" : "error message",
-    "data" : null
-}
 ```
 
-== 예외 메시지 형식
+== 실패 메시지 형식
 
 ```json
 {
-  "status" : "error",
-  "message" : "[{오류값}] {오류필드}: {오류메시지}.",
+  "status" : "fail",
+  "message" : "[{오류값}] 필드에서 잘못된 값 [{오류필드}]를 받았습니다. ({오류메시지})",
   "data" : null
 }
 ```

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -1,4 +1,4 @@
-== 회원
+== 사용자
 
 === 회원 가입
 
@@ -12,8 +12,44 @@ Response
 
 include::{snippets}/signup/회원_가입_성공/http-response.adoc[]
 
-- 400 BadRequest
+- 400 Bad Request
 
 include::{snippets}/signup/비밀번호와_비밀번호_확인이_일치하지_않으면_실패/http-response.adoc[]
 
 include::{snippets}/signup/이미_사용중인_계정명이면_실패/http-response.adoc[]
+
+=== 로그인
+
+Request
+
+include::{snippets}/login/로그인_성공/http-request.adoc[]
+
+Response
+
+- 200 OK
+
+include::{snippets}/login/로그인_성공/http-response.adoc[]
+
+- 400 Bad Request
+
+include::{snippets}/login/계정명과_비밀번호가_일치하지_않으면_실패/http-response.adoc[]
+
+=== 토큰 재발급
+
+Request
+
+include::{snippets}/reissue/토큰_재발급_성공/http-request.adoc[]
+
+Response
+
+- 200 OK
+
+include::{snippets}/reissue/토큰_재발급_성공/http-response.adoc[]
+
+- 400 Bad Request
+
+include::{snippets}/reissue/유효하지_않은_토큰이면_실패/http-response.adoc[]
+
+include::{snippets}/reissue/로그아웃한_사용자면_실패/http-response.adoc[]
+
+include::{snippets}/reissue/일치하지_않는_토큰이면_실패/http-response.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -53,3 +53,15 @@ include::{snippets}/reissue/유효하지_않은_토큰이면_실패/http-respons
 include::{snippets}/reissue/로그아웃한_사용자면_실패/http-response.adoc[]
 
 include::{snippets}/reissue/일치하지_않는_토큰이면_실패/http-response.adoc[]
+
+=== 로그아웃
+
+Request
+
+include::{snippets}/logout/로그아웃_성공/http-request.adoc[]
+
+Response
+
+- 200 OK
+
+include::{snippets}/logout/로그아웃_성공/http-response.adoc[]

--- a/src/main/java/com/budgetguard/domain/auth/api/AuthController.java
+++ b/src/main/java/com/budgetguard/domain/auth/api/AuthController.java
@@ -65,4 +65,17 @@ public class AuthController {
 		return ResponseEntity.ok()
 			.body(ApiResponse.toSuccessForm(tokenResponse));
 	}
+
+	/**
+	 * 로그아웃
+	 *
+	 * @param param accessToken, refreshToken
+	 * @return 200
+	 */
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponse> logout(@RequestBody TokenRequest param) {
+		authService.logout(param);
+		return ResponseEntity.ok()
+			.body(ApiResponse.toSuccessForm(null));
+	}
 }

--- a/src/main/java/com/budgetguard/domain/auth/api/AuthController.java
+++ b/src/main/java/com/budgetguard/domain/auth/api/AuthController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.budgetguard.domain.auth.application.AuthService;
+import com.budgetguard.domain.auth.dto.response.TokenResponse;
+import com.budgetguard.domain.member.dto.request.MemberLoginRequestParam;
 import com.budgetguard.domain.member.dto.request.MemberSignupRequestParam;
 import com.budgetguard.global.format.ApiResponse;
 
@@ -35,5 +37,18 @@ public class AuthController {
 		Long memberId = authService.signup(param);
 		return ResponseEntity.status(CREATED)
 			.body(ApiResponse.toSuccessForm(memberId));
+	}
+
+	/**
+	 * 로그인
+	 *
+	 * @param param 로그인 입력 데이터
+	 * @return 200, 로그인 성공 시 생성된 accessToken, refreshToken을 담은 tokenResponse
+	 */
+	@PostMapping("/login")
+	public ResponseEntity<ApiResponse> login(@RequestBody MemberLoginRequestParam param) {
+		TokenResponse tokenResponse = authService.login(param);
+		return ResponseEntity.ok()
+			.body(ApiResponse.toSuccessForm(tokenResponse));
 	}
 }

--- a/src/main/java/com/budgetguard/domain/auth/api/AuthController.java
+++ b/src/main/java/com/budgetguard/domain/auth/api/AuthController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.budgetguard.domain.auth.application.AuthService;
+import com.budgetguard.domain.auth.dto.request.TokenRequest;
 import com.budgetguard.domain.auth.dto.response.TokenResponse;
 import com.budgetguard.domain.member.dto.request.MemberLoginRequestParam;
 import com.budgetguard.domain.member.dto.request.MemberSignupRequestParam;
@@ -48,6 +49,19 @@ public class AuthController {
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponse> login(@RequestBody MemberLoginRequestParam param) {
 		TokenResponse tokenResponse = authService.login(param);
+		return ResponseEntity.ok()
+			.body(ApiResponse.toSuccessForm(tokenResponse));
+	}
+
+	/**
+	 * 토큰 재발급
+	 *
+	 * @param param accessToken, refreshToken
+	 * @return 200, 재발급된 accessToken, refreshToken을 담은 tokenResponse
+	 */
+	@PostMapping("/reissue")
+	public ResponseEntity<ApiResponse> reissue(@RequestBody TokenRequest param) {
+		TokenResponse tokenResponse = authService.reissue(param);
 		return ResponseEntity.ok()
 			.body(ApiResponse.toSuccessForm(tokenResponse));
 	}

--- a/src/main/java/com/budgetguard/domain/auth/application/AuthService.java
+++ b/src/main/java/com/budgetguard/domain/auth/application/AuthService.java
@@ -1,5 +1,7 @@
 package com.budgetguard.domain.auth.application;
 
+import static com.budgetguard.global.error.ErrorCode.*;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -8,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.budgetguard.domain.auth.dao.RefreshTokenRepository;
+import com.budgetguard.domain.auth.dto.request.TokenRequest;
 import com.budgetguard.domain.auth.dto.response.TokenResponse;
 import com.budgetguard.domain.auth.entity.RefreshToken;
 import com.budgetguard.domain.member.dao.MemberRepository;
@@ -80,6 +83,45 @@ public class AuthService {
 			.value(tokenResponse.getRefreshToken())
 			.build();
 		refreshTokenRepository.save(refreshToken);
+
+		return tokenResponse;
+	}
+
+	/**
+	 * 토큰 재발급
+	 *
+	 * @param tokenRequest accessToken, refreshToken
+	 * @return 재발급된 accessToken, refreshToken을 담은 tokenResponse
+	 */
+	public TokenResponse reissue(TokenRequest tokenRequest) {
+		// Refresh Token 검증
+		if (tokenManager.validateToken(tokenRequest.getRefreshToken())) {
+			throw new BusinessException(tokenRequest.getRefreshToken(), "refreshToken", INVALID_REFRESH_TOKEN);
+		}
+
+		// Access Token에서 사용자 정보 추출
+		Authentication authentication = tokenManager.createAuthentication(tokenRequest.getAccessToken());
+
+		// 계정명으로 저장된 Refresh Token을 조회
+		RefreshToken refreshToken = refreshTokenRepository.findByKey(authentication.getName()).orElseThrow(
+			() -> new BusinessException(authentication.getName(), "account", MEMBER_LOGOUT)
+		);
+
+		// 요청으로 받은 Refresh Token과 저장된 Refresh Token 일치 여부 확인
+		if (!refreshToken.getValue().equals(tokenRequest.getRefreshToken())) {
+			throw new BusinessException(tokenRequest.getRefreshToken(), "refreshToken", REFRESH_TOKEN_MISMATCH);
+		}
+
+		// 토큰 재발급
+		TokenResponse tokenResponse = tokenManager.createTokenResponse(authentication);
+
+		// 기존 Refresh Token 삭제 후 갱신된 Refresh Token 저장
+		refreshTokenRepository.delete(refreshToken);
+		RefreshToken newRefreshToken = RefreshToken.builder()
+			.key(authentication.getName())
+			.value(tokenResponse.getRefreshToken())
+			.build();
+		refreshTokenRepository.save(newRefreshToken);
 
 		return tokenResponse;
 	}

--- a/src/main/java/com/budgetguard/domain/auth/application/AuthService.java
+++ b/src/main/java/com/budgetguard/domain/auth/application/AuthService.java
@@ -125,4 +125,26 @@ public class AuthService {
 
 		return tokenResponse;
 	}
+
+	/**
+	 * 로그아웃
+	 *
+	 * @param tokenRequest accessToken, refreshToken
+	 */
+	public void logout(TokenRequest tokenRequest) {
+		// Refresh Token 검증
+		if (!tokenManager.validateToken(tokenRequest.getRefreshToken())) {
+			throw new BusinessException(tokenRequest.getRefreshToken(), "refreshToken", INVALID_REFRESH_TOKEN);
+		}
+
+		// Access Token에서 사용자 정보 추출
+		Authentication authentication = tokenManager.createAuthentication(tokenRequest.getAccessToken());
+
+		// 계정명으로 저장된 Refresh Token을 조회
+		RefreshToken refreshToken = refreshTokenRepository.findByKey(authentication.getName()).orElseThrow(
+			() -> new BusinessException(authentication.getName(), "account", MEMBER_LOGOUT)
+		);
+
+		refreshTokenRepository.delete(refreshToken);
+	}
 }

--- a/src/main/java/com/budgetguard/domain/auth/application/security/CustomAuthenticationProvider.java
+++ b/src/main/java/com/budgetguard/domain/auth/application/security/CustomAuthenticationProvider.java
@@ -1,0 +1,46 @@
+package com.budgetguard.domain.auth.application.security;
+
+import static com.budgetguard.global.error.ErrorCode.*;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import com.budgetguard.global.error.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 비밀번호 검증 시, 예외 처리를 위해서 커스텀
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+	private final CustomUserDetailsService userDetailsService;
+
+	@Override
+	public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+		String account = authentication.getName();
+		String password = (String) authentication.getCredentials();
+
+		// 계정명으로 사용자 조회
+		UserDetails member = userDetailsService.loadUserByUsername(account);
+
+		// 비밀번호 검증
+		if (!password.equals(member.getPassword())) {
+			throw new BusinessException(password, "password", WRONG_PASSWORD);
+		}
+
+		// AuthService에 Authentication 반환
+		return new UsernamePasswordAuthenticationToken(account, password, member.getAuthorities());
+	}
+
+	@Override
+	public boolean supports(Class<?> authentication) {
+		return authentication.equals(UsernamePasswordAuthenticationToken.class);
+	}
+}

--- a/src/main/java/com/budgetguard/domain/auth/application/security/CustomUserDetailsService.java
+++ b/src/main/java/com/budgetguard/domain/auth/application/security/CustomUserDetailsService.java
@@ -1,0 +1,40 @@
+package com.budgetguard.domain.auth.application.security;
+
+import java.util.Collections;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import com.budgetguard.domain.member.dao.MemberRepository;
+import com.budgetguard.domain.member.entity.Member;
+import com.budgetguard.global.error.BusinessException;
+import com.budgetguard.global.error.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * CustomAuthenticationProvider에서 사용할 UserDetails를 생성 및 예외 처리한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+	private final MemberRepository memberRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		Member member = memberRepository.findByAccount(username).orElseThrow(
+			() -> new BusinessException(username, "account", ErrorCode.MEMBER_ACCOUNT_NOT_FOUND)
+		);
+		return createUserDetails(member);
+	}
+
+	private UserDetails createUserDetails(Member member) {
+		SimpleGrantedAuthority authority = new SimpleGrantedAuthority(member.getRole().toString()); // 권한 정보 추출
+		return new User(member.getAccount(), member.getPassword(), Collections.singleton(authority));
+	}
+}

--- a/src/main/java/com/budgetguard/domain/auth/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/budgetguard/domain/auth/dao/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.budgetguard.domain.auth.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.budgetguard.domain.auth.entity.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/com/budgetguard/domain/auth/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/budgetguard/domain/auth/dao/RefreshTokenRepository.java
@@ -1,8 +1,12 @@
 package com.budgetguard.domain.auth.dao;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.budgetguard.domain.auth.entity.RefreshToken;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+	Optional<RefreshToken> findByKey(String key);
 }

--- a/src/main/java/com/budgetguard/domain/auth/dto/request/TokenRequest.java
+++ b/src/main/java/com/budgetguard/domain/auth/dto/request/TokenRequest.java
@@ -1,0 +1,19 @@
+package com.budgetguard.domain.auth.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRequest {
+
+	private String accessToken;
+	private String refreshToken;
+
+	@Builder
+	private TokenRequest(String accessToken, String refreshToken) {
+		this.accessToken = accessToken;
+		this.refreshToken = refreshToken;
+	}
+}

--- a/src/main/java/com/budgetguard/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/budgetguard/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,17 @@
+package com.budgetguard.domain.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TokenResponse {
+
+	private final String accessToken;
+	private final String refreshToken;
+
+	@Builder
+	private TokenResponse(String accessToken, String refreshToken) {
+		this.accessToken = accessToken;
+		this.refreshToken = refreshToken;
+	}
+}

--- a/src/main/java/com/budgetguard/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/budgetguard/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,27 @@
+package com.budgetguard.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RefreshToken {
+
+	@Id
+	@Column(name = "refresh_token_key", nullable = false)
+	private String key;
+
+	@Column(name = "refresh_token_value", nullable = false)
+	private String value;
+
+	@Builder
+	private RefreshToken(String key, String value) {
+		this.key = key;
+		this.value = value;
+	}
+}

--- a/src/main/java/com/budgetguard/domain/member/dto/request/MemberLoginRequestParam.java
+++ b/src/main/java/com/budgetguard/domain/member/dto/request/MemberLoginRequestParam.java
@@ -1,0 +1,19 @@
+package com.budgetguard.domain.member.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberLoginRequestParam {
+
+	private String account;
+	private String password;
+
+	@Builder
+	private MemberLoginRequestParam(String account, String password) {
+		this.account = account;
+		this.password = password;
+	}
+}

--- a/src/main/java/com/budgetguard/domain/member/entity/Member.java
+++ b/src/main/java/com/budgetguard/domain/member/entity/Member.java
@@ -2,6 +2,8 @@ package com.budgetguard.domain.member.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,10 +28,15 @@ public class Member {
 	@Column(nullable = false)
 	private String password;
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private MemberRole role;
+
 	@Builder
-	private Member(Long id, String account, String password) {
+	private Member(Long id, String account, String password, MemberRole role) {
 		this.id = id;
 		this.account = account;
 		this.password = password;
+		this.role = role;
 	}
 }

--- a/src/main/java/com/budgetguard/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/budgetguard/domain/member/entity/MemberRole.java
@@ -1,0 +1,9 @@
+package com.budgetguard.domain.member.entity;
+
+/**
+ * 스프링 시큐리티 권한
+ */
+public enum MemberRole {
+	ROLE_USER,
+	ROLE_ADMIN
+}

--- a/src/main/java/com/budgetguard/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/budgetguard/global/config/security/SecurityConfig.java
@@ -9,7 +9,9 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.budgetguard.global.config.security.filter.JwtFilter;
 import com.budgetguard.global.config.security.handler.CustomAccessDeniedHandler;
 import com.budgetguard.global.config.security.handler.CustomAuthenticationEntryPoint;
 
@@ -22,6 +24,7 @@ public class SecurityConfig {
 
 	private final CustomAccessDeniedHandler accessDeniedHandler;
 	private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+	private final TokenManager tokenManager;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -44,6 +47,9 @@ public class SecurityConfig {
 
 			.exceptionHandling(e -> e.accessDeniedHandler(accessDeniedHandler)) // 권한 없이 접근
 			.exceptionHandling(e -> e.authenticationEntryPoint(authenticationEntryPoint)) // 유효하지 않은 자격으로 접근
+
+			// 요청의 헤더에 유효한 JWT 토큰이 있으면 SecurityContext 에 저장하는 필터
+			.addFilterBefore(new JwtFilter(tokenManager), UsernamePasswordAuthenticationFilter.class)
 
 			.build();
 	}

--- a/src/main/java/com/budgetguard/global/config/security/TokenManager.java
+++ b/src/main/java/com/budgetguard/global/config/security/TokenManager.java
@@ -90,11 +90,11 @@ public class TokenManager {
 	/**
 	 * 토큰을 복호화해서 사용자 정보를 추출한다.
 	 *
-	 * @param token JWT 토큰
+	 * @param accessToken JWT 토큰
 	 * @return 사용자 정보
 	 */
-	public Authentication createAuthentication(String token) {
-		Claims claims = toClaims(token);
+	public Authentication createAuthentication(String accessToken) {
+		Claims claims = toClaims(accessToken);
 
 		// 클레임에서 권한 정보 추출
 		List<SimpleGrantedAuthority> authorities = Arrays.stream(
@@ -105,7 +105,7 @@ public class TokenManager {
 		// 권한 정보를 기반으로 UserDetails 객체를 생성한다.
 		User principal = new User(claims.getSubject(), "", authorities);
 
-		// 사용자 정보를 기반으로 사용자 정보를 생성한다.
+		// UserDetails 객체를 기반으로 사용자 정보를 생성한다.
 		return new UsernamePasswordAuthenticationToken(principal, "", authorities);
 	}
 

--- a/src/main/java/com/budgetguard/global/config/security/TokenManager.java
+++ b/src/main/java/com/budgetguard/global/config/security/TokenManager.java
@@ -1,0 +1,148 @@
+package com.budgetguard.global.config.security;
+
+import static java.lang.System.*;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import com.budgetguard.domain.auth.dto.response.TokenResponse;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 사용자 정보로 JWT 토큰을 만들거나 토큰을 바탕으로 사용자 정보를 가져온다.
+ */
+@Slf4j
+@Component
+public class TokenManager {
+
+	private static final String AUTHORITIES_KEY = "auth";
+	private static final String AUTHORITIES_SEPARATOR = ",";
+	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
+	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
+
+	private final Key key;
+
+	/**
+	 * 암호화 키 생성
+	 *
+	 * @param secretKey propertise에서 관리하는 키
+	 */
+	public TokenManager(@Value("${jwt.secret}") String secretKey) {
+		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+		this.key = Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	/**
+	 * 사용자 정보를 넘겨받아서 Access Token과 Refresh Token을 생성
+	 *
+	 * @param authentication 사용자 정보
+	 * @return JWT 토큰 Dto
+	 */
+	public TokenResponse createTokenResponse(Authentication authentication) {
+		// 권한 불러오기
+		String authorities = authentication.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(AUTHORITIES_SEPARATOR));
+
+		// Access Token 생성
+		Date accessTokenExpiration = new Date(currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME);
+		String accessToken = Jwts.builder()
+			.setSubject(authentication.getName())
+			.claim(AUTHORITIES_KEY, authorities)
+			.setExpiration(accessTokenExpiration)
+			.signWith(key, SignatureAlgorithm.HS512)
+			.compact();
+
+		// Refresh Token 생성
+		Date refreshTokenExpiration = new Date(currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME);
+		String refreshToken = Jwts.builder()
+			.setExpiration(refreshTokenExpiration)
+			.signWith(key, SignatureAlgorithm.HS512)
+			.compact();
+
+		return TokenResponse.builder()
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
+	}
+
+	/**
+	 * 토큰을 복호화해서 사용자 정보를 추출한다.
+	 *
+	 * @param token JWT 토큰
+	 * @return 사용자 정보
+	 */
+	public Authentication createAuthentication(String token) {
+		Claims claims = toClaims(token);
+
+		// 클레임에서 권한 정보 추출
+		List<SimpleGrantedAuthority> authorities = Arrays.stream(
+				claims.get(AUTHORITIES_KEY).toString().split(AUTHORITIES_SEPARATOR))
+			.map(SimpleGrantedAuthority::new)
+			.toList();
+
+		// 권한 정보를 기반으로 UserDetails 객체를 생성한다.
+		User principal = new User(claims.getSubject(), "", authorities);
+
+		// 사용자 정보를 기반으로 사용자 정보를 생성한다.
+		return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+	}
+
+	/**
+	 * 토큰을 복호화해서 클레임 정보를 추출한다.
+	 *
+	 * @param token JWT 토큰
+	 * @return 클레임 정보
+	 */
+	private Claims toClaims(String token) {
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			return e.getClaims();
+		}
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token);
+			return true;
+		} catch (SecurityException | MalformedJwtException e) {
+			log.debug("잘못된 JWT 서명입니다.");
+		} catch (ExpiredJwtException e) {
+			log.debug("만료된 JWT 토큰입니다.");
+		} catch (UnsupportedJwtException e) {
+			log.debug("지원되지 않는 JWT 토큰입니다.");
+		} catch (IllegalArgumentException e) {
+			log.debug("JWT 토큰이 잘못되었습니다.");
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/budgetguard/global/config/security/filter/JwtFilter.java
+++ b/src/main/java/com/budgetguard/global/config/security/filter/JwtFilter.java
@@ -1,0 +1,65 @@
+package com.budgetguard.global.config.security.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.budgetguard.global.config.security.TokenManager;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	private static final String BEARER_PREFIX = "Bearer ";
+	private static final int BEARER_LENGTH = 7;
+
+	private final TokenManager tokenManager;
+
+	/**
+	 * JWT 토큰의 인증 정보를 현재 스레드의 SecurityContext 에 저장한다.
+	 */
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		// 헤더에서 토큰 정보를 추출한다.
+		String token = resolveToken(request);
+
+		// 토큰이 존재하고, 유효한 경우 SecurityContext 에 저장한다.
+		if (StringUtils.hasText(token) && tokenManager.validateToken(token)) {
+			Authentication authentication = tokenManager.createAuthentication(token);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	/**
+	 * Request Header 에서 토큰 정보를 추출한다.
+	 *
+	 * @param request HttpServletRequest
+	 * @return 토큰 정보
+	 */
+	private String resolveToken(HttpServletRequest request) {
+		// 헤더에서 토큰 정보를 추출한다.
+		String token = request.getHeader(AUTHORIZATION_HEADER);
+
+		// 토큰이 존재하고, Bearer 로 시작하는 경우 토큰 정보를 반환한다.
+		if (StringUtils.hasText(token) && token.startsWith(BEARER_PREFIX)) {
+			return token.substring(BEARER_LENGTH);
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/com/budgetguard/global/error/ErrorCode.java
+++ b/src/main/java/com/budgetguard/global/error/ErrorCode.java
@@ -16,9 +16,14 @@ public enum ErrorCode {
 	INVALID_PASSWORD_CONFIRM("비밀번호와 비밀번호 확인이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 	DUPLICATED_ACCOUNT("이미 사용중인 계정명입니다.", HttpStatus.BAD_REQUEST),
 
+	// 로그인
+	WRONG_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+
 	// 인가 인증
 	ACCESS_DENIED("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-	UNAUTHORIZED_ENTRY_POINT("유효하지 않은 자격 증명입니다.", HttpStatus.UNAUTHORIZED);
+	UNAUTHORIZED_ENTRY_POINT("유효하지 않은 자격 증명입니다.", HttpStatus.UNAUTHORIZED),
+	MEMBER_ACCOUNT_NOT_FOUND("존재하지 않는 계정입니다.", HttpStatus.BAD_REQUEST)
+	;
 
 	private final String message;
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/budgetguard/global/error/ErrorCode.java
+++ b/src/main/java/com/budgetguard/global/error/ErrorCode.java
@@ -1,5 +1,7 @@
 package com.budgetguard.global.error;
 
+import static org.springframework.http.HttpStatus.*;
+
 import org.springframework.http.HttpStatus;
 
 import lombok.Getter;
@@ -13,16 +15,21 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
 	// 회원가입
-	INVALID_PASSWORD_CONFIRM("비밀번호와 비밀번호 확인이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
-	DUPLICATED_ACCOUNT("이미 사용중인 계정명입니다.", HttpStatus.BAD_REQUEST),
+	INVALID_PASSWORD_CONFIRM("비밀번호와 비밀번호 확인이 일치하지 않습니다.", BAD_REQUEST),
+	DUPLICATED_ACCOUNT("이미 사용중인 계정명입니다.", BAD_REQUEST),
 
 	// 로그인
-	WRONG_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+	WRONG_PASSWORD("비밀번호가 일치하지 않습니다.", BAD_REQUEST),
+
+	// 토큰 재발급
+	INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰입니다.", BAD_REQUEST),
+	MEMBER_LOGOUT("로그아웃된 회원입니다.", BAD_REQUEST),
+	REFRESH_TOKEN_MISMATCH("리프레시 토큰이 일치하지 않습니다.", BAD_REQUEST),
 
 	// 인가 인증
-	ACCESS_DENIED("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-	UNAUTHORIZED_ENTRY_POINT("유효하지 않은 자격 증명입니다.", HttpStatus.UNAUTHORIZED),
-	MEMBER_ACCOUNT_NOT_FOUND("존재하지 않는 계정입니다.", HttpStatus.BAD_REQUEST)
+	ACCESS_DENIED("접근 권한이 없습니다.", FORBIDDEN),
+	UNAUTHORIZED_ENTRY_POINT("유효하지 않은 자격 증명입니다.", UNAUTHORIZED),
+	MEMBER_ACCOUNT_NOT_FOUND("존재하지 않는 계정입니다.", BAD_REQUEST)
 	;
 
 	private final String message;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,6 @@ spring.datasource.password=root
 spring.jpa.hibernate.ddl-auto=create
 
 decorator.datasource.p6spy.enable-logging=true
+
+# 실제 서비스에서는 반드시 숨겨서 배포해야 한다.
+jwt.secret= c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK

--- a/src/test/java/com/budgetguard/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/budgetguard/domain/auth/api/AuthControllerTest.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @WebMvcTest(AuthController.class)
 class AuthControllerTest extends AbstractRestDocsTest {
 
-	static final String URL = "/api/v1/auth";
+	static final String AUTH_URL = "/api/v1/auth";
 	static final Member member = MemberTestHelper.createMember();
 
 	@Autowired
@@ -51,7 +51,7 @@ class AuthControllerTest extends AbstractRestDocsTest {
 
 			given(authService.signup(any())).willReturn(1L);
 
-			mockMvc.perform(post(URL + "/signup")
+			mockMvc.perform(post(AUTH_URL + "/signup")
 				.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(param)))
 				.andExpect(status().isCreated());
 		}
@@ -66,7 +66,7 @@ class AuthControllerTest extends AbstractRestDocsTest {
 				.passwordConfirm(wrongPasswordConfirm)
 				.build();
 
-			mockMvc.perform(post(URL + "/signup")
+			mockMvc.perform(post(AUTH_URL + "/signup")
 					.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(param)))
 				.andExpect(status().isBadRequest());
 		}
@@ -82,7 +82,7 @@ class AuthControllerTest extends AbstractRestDocsTest {
 
 			given(authService.signup(any())).willThrow(new BusinessException(member.getAccount(), "account", ErrorCode.DUPLICATED_ACCOUNT));
 
-			mockMvc.perform(post(URL + "/signup")
+			mockMvc.perform(post(AUTH_URL + "/signup")
 					.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(param)))
 				.andExpect(status().isBadRequest());
 		}
@@ -105,7 +105,7 @@ class AuthControllerTest extends AbstractRestDocsTest {
 
 			given(authService.login(any())).willReturn(tokenResponse);
 
-			mockMvc.perform(post(URL + "/login")
+			mockMvc.perform(post(AUTH_URL + "/login")
 					.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(param)))
 				.andExpect(status().isOk());
 		}
@@ -120,7 +120,7 @@ class AuthControllerTest extends AbstractRestDocsTest {
 
 			given(authService.login(any())).willThrow(new BusinessException(param.getPassword(), "password", WRONG_PASSWORD));
 
-			mockMvc.perform(post(URL + "/login")
+			mockMvc.perform(post(AUTH_URL + "/login")
 					.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(param)))
 				.andExpect(status().isBadRequest());
 		}
@@ -143,7 +143,7 @@ class AuthControllerTest extends AbstractRestDocsTest {
 
 			given(authService.reissue(any())).willReturn(tokenResponse);
 
-			mockMvc.perform(post(URL + "/reissue")
+			mockMvc.perform(post(AUTH_URL + "/reissue")
 					.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(tokenRequest)))
 				.andExpect(status().isOk());
 		}
@@ -158,7 +158,7 @@ class AuthControllerTest extends AbstractRestDocsTest {
 
 			given(authService.reissue(any())).willThrow(new BusinessException(tokenRequest.getRefreshToken(), "refreshToken", INVALID_REFRESH_TOKEN));
 
-			mockMvc.perform(post(URL + "/reissue")
+			mockMvc.perform(post(AUTH_URL + "/reissue")
 					.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(tokenRequest)))
 				.andExpect(status().isBadRequest());
 		}
@@ -173,7 +173,7 @@ class AuthControllerTest extends AbstractRestDocsTest {
 
 			given(authService.reissue(any())).willThrow(new BusinessException("logout account", "account", MEMBER_LOGOUT));
 
-			mockMvc.perform(post(URL + "/reissue")
+			mockMvc.perform(post(AUTH_URL + "/reissue")
 					.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(tokenRequest)))
 				.andExpect(status().isBadRequest());
 		}
@@ -188,9 +188,26 @@ class AuthControllerTest extends AbstractRestDocsTest {
 
 			given(authService.reissue(any())).willThrow(new BusinessException(tokenRequest.getRefreshToken(), "refreshToken", REFRESH_TOKEN_MISMATCH));
 
-			mockMvc.perform(post(URL + "/reissue")
+			mockMvc.perform(post(AUTH_URL + "/reissue")
 					.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(tokenRequest)))
 				.andExpect(status().isBadRequest());
+		}
+	}
+
+	@Nested
+	@DisplayName("로그아웃")
+	class logout {
+		@Test
+		@DisplayName("로그아웃 성공")
+		void 로그아웃_성공() throws Exception {
+			TokenRequest tokenRequest = TokenRequest.builder()
+				.accessToken("accessToken")
+				.refreshToken("refreshToken")
+				.build();
+
+			mockMvc.perform(post(AUTH_URL + "/logout")
+					.contentType(APPLICATION_JSON).content(mapper.writeValueAsString(tokenRequest)))
+				.andExpect(status().isOk());
 		}
 	}
 }

--- a/src/test/java/com/budgetguard/domain/member/MemberTestHelper.java
+++ b/src/test/java/com/budgetguard/domain/member/MemberTestHelper.java
@@ -1,5 +1,7 @@
 package com.budgetguard.domain.member;
 
+import static com.budgetguard.domain.member.entity.MemberRole.*;
+
 import com.budgetguard.domain.member.entity.Member;
 
 /**
@@ -12,6 +14,7 @@ public class MemberTestHelper {
 			.id(1L)
 			.account("testAccount")
 			.password("Password123!")
+			.role(ROLE_USER)
 			.build();
 	}
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: #7 

## 📝 Description

* JWT 필터를 추가하여 요청의 헤더에 들어있는 JWT 토큰에서 사용자 정보를 읽고 SecurityContext에 저장합니다.

* JWT 토큰과 사용자 정보를 convert하는 TokenManager 클래스를 생성했습니다.

* 로그인 및 로그아웃 기능을 구현했습니다.

* 토큰 재발급 기능을 구현했습니다.

## ⭐️ Review

필터에서 SecurityContext에 저장한 사용자 정보를 정확히 어떤 과정에서 사용하는 것인지 모호합니다.