### PR TITLE
Feature/#13 지출 crud 구현

### DIFF
--- a/src/docs/asciidoc/budget.adoc
+++ b/src/docs/asciidoc/budget.adoc
@@ -24,7 +24,7 @@ Response
 
 include::{snippets}/create-budget/예산_설정_성공/http-response.adoc[]
 
-- 400 Bad Request
+- 404 Not Found
 
 include::{snippets}/create-budget/존재하지_않는_사용자로_요청하면_실패/http-response.adoc[]
 

--- a/src/docs/asciidoc/expenditure.adoc
+++ b/src/docs/asciidoc/expenditure.adoc
@@ -1,0 +1,17 @@
+== 지출
+
+=== 지출 생성
+
+Request
+
+include::{snippets}/create-expenditure/지출_생성_성공/http-request.adoc[]
+
+Response
+
+- 200 OK
+
+include::{snippets}/create-expenditure/지출_생성_성공/http-response.adoc[]
+
+- 400 Bad Request
+
+include::{snippets}/create-expenditure/지출을_음수로_생성하면_실패/http-response.adoc[]

--- a/src/docs/asciidoc/expenditure.adoc
+++ b/src/docs/asciidoc/expenditure.adoc
@@ -31,3 +31,19 @@ include::{snippets}/update-expenditure/지출_수정_성공/http-response.adoc[]
 - 400 Bad Request
 
 include::{snippets}/update-expenditure/지출을_음수로_수정하면_실패/http-response.adoc[]
+
+=== 지출 상세 조회
+
+Request
+
+include::{snippets}/get-expenditure/지출_상세_조회_성공/http-request.adoc[]
+
+Response
+
+- 200 OK
+
+include::{snippets}/get-expenditure/지출_상세_조회_성공/http-response.adoc[]
+
+- 404 Not Found
+
+include::{snippets}/get-expenditure/존재하지_않는_지출을_조회하면_실패/http-response.adoc[]

--- a/src/docs/asciidoc/expenditure.adoc
+++ b/src/docs/asciidoc/expenditure.adoc
@@ -63,3 +63,15 @@ include::{snippets}/delete-expenditure/지출_삭제_성공/http-response.adoc[]
 - 404 Not Found
 
 include::{snippets}/delete-expenditure/존재하지_않는_지출을_삭제하면_실패/http-response.adoc[]
+
+== 지출 목록 검색
+
+Request
+
+include::{snippets}/search-expenditures/지출_목록_검색_성공/http-request.adoc[]
+
+Response
+
+- 200 OK
+
+include::{snippets}/search-expenditures/지출_목록_검색_성공/http-response.adoc[]

--- a/src/docs/asciidoc/expenditure.adoc
+++ b/src/docs/asciidoc/expenditure.adoc
@@ -47,3 +47,19 @@ include::{snippets}/get-expenditure/지출_상세_조회_성공/http-response.ad
 - 404 Not Found
 
 include::{snippets}/get-expenditure/존재하지_않는_지출을_조회하면_실패/http-response.adoc[]
+
+=== 지출 삭제
+
+Request
+
+include::{snippets}/delete-expenditure/지출_삭제_성공/http-request.adoc[]
+
+Response
+
+- 200 OK
+
+include::{snippets}/delete-expenditure/지출_삭제_성공/http-response.adoc[]
+
+- 404 Not Found
+
+include::{snippets}/delete-expenditure/존재하지_않는_지출을_삭제하면_실패/http-response.adoc[]

--- a/src/docs/asciidoc/expenditure.adoc
+++ b/src/docs/asciidoc/expenditure.adoc
@@ -15,3 +15,19 @@ include::{snippets}/create-expenditure/지출_생성_성공/http-response.adoc[]
 - 400 Bad Request
 
 include::{snippets}/create-expenditure/지출을_음수로_생성하면_실패/http-response.adoc[]
+
+=== 지출 수정
+
+Request
+
+include::{snippets}/update-expenditure/지출_수정_성공/http-request.adoc[]
+
+Response
+
+- 200 OK
+
+include::{snippets}/update-expenditure/지출_수정_성공/http-response.adoc[]
+
+- 400 Bad Request
+
+include::{snippets}/update-expenditure/지출을_음수로_수정하면_실패/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -64,3 +64,4 @@
 
 include::member.adoc[]
 include::budget.adoc[]
+include::expenditure.adoc[]

--- a/src/main/java/com/budgetguard/domain/budget/application/BudgetService.java
+++ b/src/main/java/com/budgetguard/domain/budget/application/BudgetService.java
@@ -62,7 +62,8 @@ public class BudgetService {
 		Budget savedBudget = budgetRepository.save(budget);
 
 		// 예산을 사용자의 월간 총 예산에 추가한다.
-		changeTotalBudgetAmount(member, member.getMonthlyOverview().getTotalBudgetAmount() + param.getAmount());
+		int amount = member.getMonthlyOverview().getTotalBudgetAmount() + param.getAmount();
+		changeTotalBudgetAmount(member, amount);
 
 		return savedBudget.getId();
 	}
@@ -90,7 +91,8 @@ public class BudgetService {
 		Member member = memberRepository.findById(param.getMemberId()).orElseThrow(
 			() -> new BusinessException(param.getMemberId(), "memberId", MEMBER_NOT_FOUND)
 		);
-		changeTotalBudgetAmount(member, afterAmount - beforeAmount);
+		int amount = member.getMonthlyOverview().getTotalBudgetAmount() + (afterAmount - beforeAmount);
+		changeTotalBudgetAmount(member, amount);
 
 		return budgetId;
 	}

--- a/src/main/java/com/budgetguard/domain/budget/dao/BudgetRepository.java
+++ b/src/main/java/com/budgetguard/domain/budget/dao/BudgetRepository.java
@@ -3,10 +3,17 @@ package com.budgetguard.domain.budget.dao;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.budgetguard.domain.budget.entity.Budget;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
 
-	Optional<Budget> findByMemberIdAndCategoryId(Long memberId, Long categoryId);
+	@Query("SELECT b "
+		+ "FROM Budget b "
+		+ "LEFT JOIN FETCH b.category "
+		+ "WHERE b.member.id =:memberId "
+		+ "AND b.category.id =:categoryId")
+	Optional<Budget> findByMemberIdAndCategoryId(@Param("memberId") Long memberId, @Param("categoryId") Long categoryId);
 }

--- a/src/main/java/com/budgetguard/domain/expenditure/api/ExpenditureController.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/api/ExpenditureController.java
@@ -4,7 +4,9 @@ import static org.springframework.http.HttpHeaders.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.budgetguard.domain.auth.application.AuthService;
 import com.budgetguard.domain.expenditure.application.ExpenditureService;
 import com.budgetguard.domain.expenditure.dto.ExpenditureCreateRequestParam;
+import com.budgetguard.domain.expenditure.dto.ExpenditureUpdateRequestParam;
 import com.budgetguard.global.format.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -42,5 +45,25 @@ public class ExpenditureController {
 
 		Long expenditureId = expenditureService.createExpenditure(param);
 		return ResponseEntity.ok(ApiResponse.toSuccessForm(expenditureId));
+	}
+
+	/**
+	 * 지출을 수정한다.
+	 *
+	 * @param token JWT 토큰
+	 * @param expenditureId 수정할 지출의 ID
+	 * @param param 지출 수정 요청 파라미터
+	 * @return 수정된 지출의 ID
+	 */
+	@PutMapping("/{expenditureId}")
+	public ResponseEntity<ApiResponse> updateExpenditure(
+		@RequestHeader(AUTHORIZATION) String token,
+		@PathVariable Long expenditureId,
+		@RequestBody @Validated ExpenditureUpdateRequestParam param
+	) {
+		// 토큰의 account와 지출을 수정할 account는 같아야 한다.
+		authService.validSameTokenAccount(token, param.getMemberId());
+
+		return ResponseEntity.ok(ApiResponse.toSuccessForm(expenditureService.updateExpenditure(expenditureId, param)));
 	}
 }

--- a/src/main/java/com/budgetguard/domain/expenditure/api/ExpenditureController.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/api/ExpenditureController.java
@@ -1,0 +1,46 @@
+package com.budgetguard.domain.expenditure.api;
+
+import static org.springframework.http.HttpHeaders.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.budgetguard.domain.auth.application.AuthService;
+import com.budgetguard.domain.expenditure.application.ExpenditureService;
+import com.budgetguard.domain.expenditure.dto.ExpenditureCreateRequestParam;
+import com.budgetguard.global.format.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/expenditures")
+public class ExpenditureController {
+
+	private final ExpenditureService expenditureService;
+	private final AuthService authService;
+
+	/**
+	 * 지출을 생성한다.
+	 *
+	 * @param token JWT 토큰
+	 * @param param 지출 생성 요청 파라미터
+	 * @return 생성된 지출의 ID
+	 */
+	@PostMapping
+	public ResponseEntity<ApiResponse> createExpenditure(
+		@RequestHeader(AUTHORIZATION) String token,
+		@RequestBody @Validated ExpenditureCreateRequestParam param
+	) {
+		// 토큰의 account와 지출을 생성할 account는 같아야 한다.
+		authService.validSameTokenAccount(token, param.getMemberId());
+
+		Long expenditureId = expenditureService.createExpenditure(param);
+		return ResponseEntity.ok(ApiResponse.toSuccessForm(expenditureId));
+	}
+}

--- a/src/main/java/com/budgetguard/domain/expenditure/api/ExpenditureController.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/api/ExpenditureController.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpHeaders.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import com.budgetguard.domain.auth.application.AuthService;
 import com.budgetguard.domain.expenditure.application.ExpenditureService;
 import com.budgetguard.domain.expenditure.dto.request.ExpenditureCreateRequestParam;
 import com.budgetguard.domain.expenditure.dto.request.ExpenditureUpdateRequestParam;
+import com.budgetguard.domain.expenditure.dto.response.ExpenditureDetailResponse;
 import com.budgetguard.global.format.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -83,6 +85,25 @@ public class ExpenditureController {
 		// 토큰의 account와 지출을 조회할 account는 같아야 한다.
 		authService.validSameTokenAccount(token, expenditureService.getExpenditure(expenditureId).getMemberId());
 
-		return ResponseEntity.ok(ApiResponse.toSuccessForm(expenditureService.getExpenditure(expenditureId)));
+		ExpenditureDetailResponse expenditureDetail = expenditureService.getExpenditure(expenditureId);
+		return ResponseEntity.ok(ApiResponse.toSuccessForm(expenditureDetail));
+	}
+
+	/**
+	 * 지출을 삭제한다.
+	 *
+	 * @param token JWT 토큰
+	 * @param expenditureId 삭제할 지출의 ID
+	 * @return 삭제된 지출의 ID
+	 */
+	@DeleteMapping("/{expenditureId}")
+	public ResponseEntity<ApiResponse> deleteExpenditure(
+		@RequestHeader(AUTHORIZATION) String token,
+		@PathVariable Long expenditureId
+	) {
+		// 토큰의 account와 지출을 삭제할 account는 같아야 한다.
+		authService.validSameTokenAccount(token, expenditureService.getExpenditure(expenditureId).getMemberId());
+
+		return ResponseEntity.ok(ApiResponse.toSuccessForm(expenditureService.deleteExpenditure(expenditureId)));
 	}
 }

--- a/src/main/java/com/budgetguard/domain/expenditure/api/ExpenditureController.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/api/ExpenditureController.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpHeaders.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -14,8 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.budgetguard.domain.auth.application.AuthService;
 import com.budgetguard.domain.expenditure.application.ExpenditureService;
-import com.budgetguard.domain.expenditure.dto.ExpenditureCreateRequestParam;
-import com.budgetguard.domain.expenditure.dto.ExpenditureUpdateRequestParam;
+import com.budgetguard.domain.expenditure.dto.request.ExpenditureCreateRequestParam;
+import com.budgetguard.domain.expenditure.dto.request.ExpenditureUpdateRequestParam;
 import com.budgetguard.global.format.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -65,5 +66,23 @@ public class ExpenditureController {
 		authService.validSameTokenAccount(token, param.getMemberId());
 
 		return ResponseEntity.ok(ApiResponse.toSuccessForm(expenditureService.updateExpenditure(expenditureId, param)));
+	}
+
+	/**
+	 * 지출을 상세 조회한다.
+	 *
+	 * @param token JWT 토큰
+	 * @param expenditureId 조회할 지출의 ID
+	 * @return 지출 상세 정보
+	 */
+	@GetMapping("/{expenditureId}")
+	public ResponseEntity<ApiResponse> getExpenditure(
+		@RequestHeader(AUTHORIZATION) String token,
+		@PathVariable Long expenditureId
+	) {
+		// 토큰의 account와 지출을 조회할 account는 같아야 한다.
+		authService.validSameTokenAccount(token, expenditureService.getExpenditure(expenditureId).getMemberId());
+
+		return ResponseEntity.ok(ApiResponse.toSuccessForm(expenditureService.getExpenditure(expenditureId)));
 	}
 }

--- a/src/main/java/com/budgetguard/domain/expenditure/application/ExpenditureService.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/application/ExpenditureService.java
@@ -9,8 +9,9 @@ import com.budgetguard.domain.budget.constant.CategoryName;
 import com.budgetguard.domain.budget.dao.budgetcategory.BudgetCategoryRepository;
 import com.budgetguard.domain.budget.entity.budgetcategory.BudgetCategory;
 import com.budgetguard.domain.expenditure.dao.ExpenditureRepository;
-import com.budgetguard.domain.expenditure.dto.ExpenditureCreateRequestParam;
-import com.budgetguard.domain.expenditure.dto.ExpenditureUpdateRequestParam;
+import com.budgetguard.domain.expenditure.dto.request.ExpenditureCreateRequestParam;
+import com.budgetguard.domain.expenditure.dto.request.ExpenditureUpdateRequestParam;
+import com.budgetguard.domain.expenditure.dto.response.ExpenditureDetailResponse;
 import com.budgetguard.domain.expenditure.entity.Expenditure;
 import com.budgetguard.domain.member.dao.MemberRepository;
 import com.budgetguard.domain.member.entity.Member;
@@ -90,6 +91,20 @@ public class ExpenditureService {
 		changeTotalExpenditureAmount(member, amount);
 
 		return expenditure.getId();
+	}
+
+	/**
+	 * 지출을 상세 조회한다.
+	 *
+	 * @param expenditureId 조회할 지출의 ID
+	 * @return 지출 상세 조회 응답
+	 */
+	public ExpenditureDetailResponse getExpenditure(Long expenditureId) {
+		Expenditure expenditure = expenditureRepository.findById(expenditureId).orElseThrow(
+			() -> new BusinessException(expenditureId, "expenditureId", ErrorCode.EXPENDITURE_NOT_FOUND)
+		);
+
+		return new ExpenditureDetailResponse(expenditure);
 	}
 
 	/**

--- a/src/main/java/com/budgetguard/domain/expenditure/application/ExpenditureService.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/application/ExpenditureService.java
@@ -10,10 +10,12 @@ import com.budgetguard.domain.budget.dao.budgetcategory.BudgetCategoryRepository
 import com.budgetguard.domain.budget.entity.budgetcategory.BudgetCategory;
 import com.budgetguard.domain.expenditure.dao.ExpenditureRepository;
 import com.budgetguard.domain.expenditure.dto.ExpenditureCreateRequestParam;
+import com.budgetguard.domain.expenditure.dto.ExpenditureUpdateRequestParam;
 import com.budgetguard.domain.expenditure.entity.Expenditure;
 import com.budgetguard.domain.member.dao.MemberRepository;
 import com.budgetguard.domain.member.entity.Member;
 import com.budgetguard.global.error.BusinessException;
+import com.budgetguard.global.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -55,5 +57,25 @@ public class ExpenditureService {
 		Expenditure savedExpenditure = expenditureRepository.save(expenditure);
 
 		return savedExpenditure.getId();
+	}
+
+	/**
+	 * 지출을 수정한다.
+	 *
+	 * @param expenditureId 수정할 지출의 ID
+	 * @param param 지출 수정 요청 파라미터
+	 * @return 수정된 지출의 ID
+	 */
+	public Long updateExpenditure(Long expenditureId, ExpenditureUpdateRequestParam param) {
+
+		// 지출 수정 요청 파라미터의 memberId로 회원을 찾는다.
+		Expenditure expenditure = expenditureRepository.findById(expenditureId).orElseThrow(
+			() -> new BusinessException(expenditureId, "expenditureId", ErrorCode.EXPENDITURE_NOT_FOUND)
+		);
+
+		// 지출을 수정한다.
+		expenditure.update(param.toEntity());
+
+		return expenditure.getId();
 	}
 }

--- a/src/main/java/com/budgetguard/domain/expenditure/application/ExpenditureService.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/application/ExpenditureService.java
@@ -83,7 +83,7 @@ public class ExpenditureService {
 		expenditure.update(param.toEntity());
 		int afterAmount = expenditure.getAmount();
 
-		// 사용자의 월간 오버뷰에 반영한다.
+		// 수정된 지출을 사용자의 월간 오버뷰에 반영한다.
 		Member member = memberRepository.findById(param.getMemberId()).orElseThrow(
 			() -> new BusinessException(param.getMemberId(), "memberId", MEMBER_NOT_FOUND)
 		);
@@ -105,6 +105,28 @@ public class ExpenditureService {
 		);
 
 		return new ExpenditureDetailResponse(expenditure);
+	}
+
+	/**
+	 * 지출을 삭제한다.
+	 *
+	 * @param expenditureId 삭제할 지출의 ID
+	 * @return 삭제된 지출의 ID
+	 */
+	public Long deleteExpenditure(Long expenditureId) {
+
+		Expenditure expenditure = expenditureRepository.findById(expenditureId).orElseThrow(
+			() -> new BusinessException(expenditureId, "expenditureId", ErrorCode.EXPENDITURE_NOT_FOUND)
+		);
+
+		// 삭제된 지출을 사용자의 월간 오버뷰에 반영한다.
+		Member member = expenditure.getMember();
+		int amount = member.getMonthlyOverview().getTotalExpenditureAmount() - expenditure.getAmount();
+		changeTotalExpenditureAmount(member, amount);
+
+		expenditureRepository.delete(expenditure);
+
+		return expenditureId;
 	}
 
 	/**

--- a/src/main/java/com/budgetguard/domain/expenditure/application/ExpenditureService.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/application/ExpenditureService.java
@@ -1,0 +1,59 @@
+package com.budgetguard.domain.expenditure.application;
+
+import static com.budgetguard.global.error.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.budgetguard.domain.budget.constant.CategoryName;
+import com.budgetguard.domain.budget.dao.budgetcategory.BudgetCategoryRepository;
+import com.budgetguard.domain.budget.entity.budgetcategory.BudgetCategory;
+import com.budgetguard.domain.expenditure.dao.ExpenditureRepository;
+import com.budgetguard.domain.expenditure.dto.ExpenditureCreateRequestParam;
+import com.budgetguard.domain.expenditure.entity.Expenditure;
+import com.budgetguard.domain.member.dao.MemberRepository;
+import com.budgetguard.domain.member.entity.Member;
+import com.budgetguard.global.error.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ExpenditureService {
+
+	private final ExpenditureRepository expenditureRepository;
+	private final MemberRepository memberRepository;
+	private final BudgetCategoryRepository budgetCategoryRepository;
+
+	/**
+	 * 지출을 생성한다.
+	 *
+	 * @param param 지출 생성 요청 파라미터
+	 * @return 생성된 지출의 ID
+	 */
+	public Long createExpenditure(ExpenditureCreateRequestParam param) {
+
+		// 지출 생성 요청 파라미터의 memberId로 회원을 찾는다.
+		Member member = memberRepository.findById(param.getMemberId()).orElseThrow(
+			() -> new BusinessException(param.getMemberId(), "memberId", MEMBER_NOT_FOUND)
+		);
+
+		// 지출 생성 요청 파라미터의 categoryName으로 예산 카테고리를 찾는다.
+		CategoryName categoryName = CategoryName.of(param.getCategoryName());
+		BudgetCategory budgetCategory = budgetCategoryRepository.findByName(categoryName).orElseThrow(
+			() -> new BusinessException(param.getCategoryName(), "categoryName", BUDGET_CATEGORY_NOT_FOUND)
+		);
+
+		Expenditure expenditure = Expenditure.builder()
+			.member(member)
+			.budgetCategory(budgetCategory)
+			.amount(param.getAmount())
+			.memo(param.getMemo())
+			.isExcluded(param.getIsExcluded())
+			.build();
+		Expenditure savedExpenditure = expenditureRepository.save(expenditure);
+
+		return savedExpenditure.getId();
+	}
+}

--- a/src/main/java/com/budgetguard/domain/expenditure/dao/ExpenditureQuerydslRepository.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dao/ExpenditureQuerydslRepository.java
@@ -1,0 +1,20 @@
+package com.budgetguard.domain.expenditure.dao;
+
+import java.util.List;
+
+import com.budgetguard.domain.expenditure.dto.request.ExpenditureSearchCond;
+import com.budgetguard.domain.expenditure.entity.Expenditure;
+
+/**
+ * querydsl을 사용한 지출 조회용 레포지토리
+ */
+public interface ExpenditureQuerydslRepository {
+
+	/**
+	 * 검색 조건에 부합하는 지출 목록을 조회한다.
+	 *
+	 * @param searchCond 검색 조건
+	 * @return 검색 조건에 부합하는 지출 목록
+	 */
+	List<Expenditure> searchExpenditures(ExpenditureSearchCond searchCond);
+}

--- a/src/main/java/com/budgetguard/domain/expenditure/dao/ExpenditureQuerydslRepositoryImpl.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dao/ExpenditureQuerydslRepositoryImpl.java
@@ -1,0 +1,118 @@
+package com.budgetguard.domain.expenditure.dao;
+
+import static com.budgetguard.domain.budget.entity.budgetcategory.QBudgetCategory.*;
+import static com.budgetguard.domain.expenditure.entity.QExpenditure.*;
+import static com.budgetguard.domain.member.entity.QMember.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.budgetguard.domain.budget.constant.CategoryName;
+import com.budgetguard.domain.expenditure.dto.request.ExpenditureSearchCond;
+import com.budgetguard.domain.expenditure.entity.Expenditure;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * querydsl을 사용한 지출 조회용 레포지토리 구현체
+ * 인터페이스 이름 + Impl 형식으로 클래스를 생성해야 스프링에 자동으로 등록된다.
+ */
+public class ExpenditureQuerydslRepositoryImpl implements ExpenditureQuerydslRepository {
+
+	private final JPAQueryFactory query;
+
+	public ExpenditureQuerydslRepositoryImpl(EntityManager em) {
+		this.query = new JPAQueryFactory(em);
+	}
+
+	/**
+	 * 검색 조건에 부합하는 지출을 조회한다.
+	 *
+	 * @param searchCond 검색 조건
+	 * @return 검색 조건에 부합하는 지출 리스트
+	 */
+	@Override
+	public List<Expenditure> searchExpenditures(ExpenditureSearchCond searchCond) {
+		return query
+			.select(expenditure)
+			.from(expenditure)
+			.join(expenditure.member, member).fetchJoin()
+			.join(expenditure.budgetCategory, budgetCategory).fetchJoin()
+
+			// 필수가 아닌 검색 조건은 null 일 경우 무시하는 동적 검색
+			.where(
+				isMemberIdEqual(searchCond.getMemberId()),
+				isCreatedDateBetween(searchCond.getStartDate(), searchCond.getEndDate()),
+				isCategoryEqual(searchCond.getCategoryName()),
+				isAmountBetween(searchCond.getMinAmount(), searchCond.getMaxAmount())
+			)
+
+			.fetch();
+	}
+
+	/**
+	 * 해당 사용자의 지출만을 조회한다.
+	 *
+	 * @param memberId 사용자 ID
+	 * @return 해당 사용자의 지출 리스트
+	 */
+	private BooleanExpression isMemberIdEqual(Long memberId) {
+		return expenditure.member.id.eq(memberId);
+	}
+
+	/**
+	 * 검색 시작일과 종료일 사이의 지출을 조회한다.
+	 *
+	 * @param startDate 검색 시작일
+	 * @param endDate 검색 종료일
+	 * @return 검색 시작일과 종료일 사이의 지출 리스트
+	 */
+	private BooleanExpression isCreatedDateBetween(LocalDate startDate, LocalDate endDate) {
+		return expenditure.createdTime.between(startDate.atStartOfDay(), endDate.atStartOfDay().plusDays(1).minusNanos(1));
+	}
+
+	/**
+	 * 검색 조건에 categoryName이 포함되어 있으면 해당 카테고리만 조회한다.
+	 * categoryName이 null이면 모든 카테고리를 조회한다.
+	 *
+	 * @param categoryName 카테고리 이름
+	 * @return 카테고리 이름이 일치하는 지출 리스트
+	 */
+	private BooleanExpression isCategoryEqual(String categoryName) {
+		// categoryName이 null이면 모든 카테고리를 조회한다.
+		if (categoryName == null) {
+			return null;
+		}
+		return budgetCategory.name.eq(CategoryName.of(categoryName));
+	}
+
+	/**
+	 * 검색 조건에 최소 금액과 최대 금액 각각의 포함 여부에 따라 지출을 조회한다.
+	 *
+	 * @param minAmount 최소 금액
+	 * @param maxAmount 최대 금액
+	 * @return 최소 금액과 최대 금액 각각의 포함 여부에 따라 지출 리스트
+	 */
+	private BooleanExpression isAmountBetween(Integer minAmount, Integer maxAmount) {
+
+		// minAmount와 maxAmount가 모두 null이면 모든 지출액을 조회한다.
+		if (minAmount == null && maxAmount == null) {
+			return null;
+		}
+
+		// minAmount만 null이면 지출액이 maxAmount 이하인 지출을 조회한다.
+		if (maxAmount == null) {
+			return expenditure.amount.goe(minAmount);
+		}
+
+		// maxAmount만 null이면 지출액이 minAmount 이상인 지출을 조회한다.
+		if (minAmount == null) {
+			return expenditure.amount.loe(maxAmount);
+		}
+
+		// minAmount와 maxAmount가 모두 null이 아니면 지출액이 minAmount 이상 maxAmount 이하인 지출을 조회한다.
+		return expenditure.amount.between(minAmount, maxAmount);
+	}
+}

--- a/src/main/java/com/budgetguard/domain/expenditure/dao/ExpenditureRepository.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dao/ExpenditureRepository.java
@@ -1,0 +1,8 @@
+package com.budgetguard.domain.expenditure.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.budgetguard.domain.expenditure.entity.Expenditure;
+
+public interface ExpenditureRepository extends JpaRepository<Expenditure, Long> {
+}

--- a/src/main/java/com/budgetguard/domain/expenditure/dao/ExpenditureRepository.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dao/ExpenditureRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.budgetguard.domain.expenditure.entity.Expenditure;
 
-public interface ExpenditureRepository extends JpaRepository<Expenditure, Long> {
+public interface ExpenditureRepository extends JpaRepository<Expenditure, Long>, ExpenditureQuerydslRepository {
 }

--- a/src/main/java/com/budgetguard/domain/expenditure/dto/ExpenditureCreateRequestParam.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dto/ExpenditureCreateRequestParam.java
@@ -1,0 +1,41 @@
+package com.budgetguard.domain.expenditure.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 지출 생성 요청 파라미터
+ */
+@Getter
+@NoArgsConstructor
+public class ExpenditureCreateRequestParam {
+
+	@NotNull(message = "사용자 ID를 입력해주세요")
+	private Long memberId;
+
+	@NotEmpty(message = "카테고리 이름을 입력해주세요")
+	private String categoryName;
+
+	@PositiveOrZero(message = "지출 금액은 0 이상이어야 합니다")
+	private Integer amount;
+
+	@NotEmpty(message = "메모를 입력해주세요")
+	private String memo;
+
+	@NotNull(message = "합계 제외 여부를 입력해주세요")
+	private Boolean isExcluded;
+
+	@Builder
+	private ExpenditureCreateRequestParam(Long memberId, String categoryName, Integer amount, String memo,
+		Boolean isExcluded) {
+		this.memberId = memberId;
+		this.categoryName = categoryName;
+		this.amount = amount;
+		this.memo = memo;
+		this.isExcluded = isExcluded;
+	}
+}

--- a/src/main/java/com/budgetguard/domain/expenditure/dto/ExpenditureUpdateRequestParam.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dto/ExpenditureUpdateRequestParam.java
@@ -1,0 +1,52 @@
+package com.budgetguard.domain.expenditure.dto;
+
+import com.budgetguard.domain.expenditure.entity.Expenditure;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 지출 수정 요청 파라미터
+ */
+@Getter
+@NoArgsConstructor
+public class ExpenditureUpdateRequestParam {
+
+	@NotNull(message = "사용자 ID를 입력해주세요")
+	private Long memberId;
+
+	@PositiveOrZero(message = "지출 금액은 0 이상이어야 합니다")
+	private Integer amount;
+
+	@NotEmpty(message = "메모를 입력해주세요")
+	private String memo;
+
+	@NotNull(message = "합계 제외 여부를 입력해주세요")
+	private Boolean isExcluded;
+
+	@Builder
+	private ExpenditureUpdateRequestParam(Long memberId, Integer amount, String memo, Boolean isExcluded) {
+		this.memberId = memberId;
+		this.amount = amount;
+		this.memo = memo;
+		this.isExcluded = isExcluded;
+	}
+
+	/**
+	 * 지출 수정 요청 파라미터를 지출 엔티티로 변환한다.
+	 * 변환된 엔티티는 지출 엔티티의 수정 메서드에 전달된다.
+	 *
+	 * @return 수정 내용을 담은 지출 엔티티
+	 */
+	public Expenditure toEntity() {
+		return Expenditure.builder()
+			.amount(this.amount)
+			.memo(this.memo)
+			.isExcluded(this.isExcluded)
+			.build();
+	}
+}

--- a/src/main/java/com/budgetguard/domain/expenditure/dto/request/ExpenditureCreateRequestParam.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dto/request/ExpenditureCreateRequestParam.java
@@ -1,4 +1,4 @@
-package com.budgetguard.domain.expenditure.dto;
+package com.budgetguard.domain.expenditure.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/budgetguard/domain/expenditure/dto/request/ExpenditureSearchCond.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dto/request/ExpenditureSearchCond.java
@@ -1,0 +1,45 @@
+package com.budgetguard.domain.expenditure.dto.request;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 지출 목록 검색 조건
+ */
+@Getter
+@NoArgsConstructor
+public class ExpenditureSearchCond {
+
+	@NotNull(message = "사용자 ID를 입력해주세요")
+	private Long memberId;
+
+	@NotNull(message = "조회 시작일을 입력해주세요")
+	private LocalDate startDate;
+
+	@NotNull(message = "조회 종료일을 입력해주세요")
+	private LocalDate endDate;
+
+	// null이면 모든 카테고리를 조회한다.
+	private String categoryName;
+
+	// null이면 0원부터 조회한다.
+	private Integer minAmount;
+
+	// null이면 Integer.MAX_VALUE원까지 조회한다.
+	private Integer maxAmount;
+
+	@Builder
+	private ExpenditureSearchCond(Long memberId, LocalDate startDate, LocalDate endDate, String categoryName,
+		Integer minAmount, Integer maxAmount) {
+		this.memberId = memberId;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.categoryName = categoryName;
+		this.minAmount = minAmount;
+		this.maxAmount = maxAmount;
+	}
+}

--- a/src/main/java/com/budgetguard/domain/expenditure/dto/request/ExpenditureUpdateRequestParam.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dto/request/ExpenditureUpdateRequestParam.java
@@ -1,4 +1,4 @@
-package com.budgetguard.domain.expenditure.dto;
+package com.budgetguard.domain.expenditure.dto.request;
 
 import com.budgetguard.domain.expenditure.entity.Expenditure;
 

--- a/src/main/java/com/budgetguard/domain/expenditure/dto/response/ExpenditureDetailResponse.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dto/response/ExpenditureDetailResponse.java
@@ -1,0 +1,27 @@
+package com.budgetguard.domain.expenditure.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.budgetguard.domain.expenditure.entity.Expenditure;
+
+import lombok.Getter;
+
+@Getter
+public class ExpenditureDetailResponse {
+
+	private final Long memberId;
+	private final Long budgetCategoryId;
+	private final Integer amount;
+	private final String memo;
+	private final Boolean isExcluded;
+	private final LocalDateTime createdTime;
+
+	public ExpenditureDetailResponse(Expenditure expenditure) {
+		this.memberId = expenditure.getMember().getId();
+		this.budgetCategoryId = expenditure.getBudgetCategory().getId();
+		this.amount = expenditure.getAmount();
+		this.memo = expenditure.getMemo();
+		this.isExcluded = expenditure.getIsExcluded();
+		this.createdTime = expenditure.getCreatedTime();
+	}
+}

--- a/src/main/java/com/budgetguard/domain/expenditure/dto/response/ExpenditureSearchResponse.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dto/response/ExpenditureSearchResponse.java
@@ -1,0 +1,33 @@
+package com.budgetguard.domain.expenditure.dto.response;
+
+import java.util.List;
+import java.util.Map;
+
+import com.budgetguard.domain.budget.constant.CategoryName;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 지출 검색 응답 dto
+ */
+@Getter
+public class ExpenditureSearchResponse {
+
+	// 지출 목록
+	List<ExpenditureSimpleResponse> expenditures;
+
+	// 지출 총 합계
+	private final Integer totalAmount;
+
+	// 카테고리별 지출 합계
+	private final Map<CategoryName, Integer> amountPerCategory;
+
+	@Builder
+	private ExpenditureSearchResponse(List<ExpenditureSimpleResponse> expenditures, Integer totalAmount,
+		Map<CategoryName, Integer> amountPerCategory) {
+		this.expenditures = expenditures;
+		this.totalAmount = totalAmount;
+		this.amountPerCategory = amountPerCategory;
+	}
+}

--- a/src/main/java/com/budgetguard/domain/expenditure/dto/response/ExpenditureSimpleResponse.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/dto/response/ExpenditureSimpleResponse.java
@@ -1,30 +1,22 @@
 package com.budgetguard.domain.expenditure.dto.response;
 
-import java.time.LocalDateTime;
-
 import com.budgetguard.domain.expenditure.entity.Expenditure;
 
 import lombok.Getter;
 
 /**
- * 지출 상세 조회 응답 dto
+ * 지출 검색 목록에서 보이는 간단한 응답 dto
  */
 @Getter
-public class ExpenditureDetailResponse {
+public class ExpenditureSimpleResponse {
 
 	private final Long memberId;
 	private final Long budgetCategoryId;
 	private final Integer amount;
-	private final String memo;
-	private final Boolean isExcluded;
-	private final LocalDateTime createdTime;
 
-	public ExpenditureDetailResponse(Expenditure expenditure) {
+	public ExpenditureSimpleResponse(Expenditure expenditure) {
 		this.memberId = expenditure.getMember().getId();
 		this.budgetCategoryId = expenditure.getBudgetCategory().getId();
 		this.amount = expenditure.getAmount();
-		this.memo = expenditure.getMemo();
-		this.isExcluded = expenditure.getIsExcluded();
-		this.createdTime = expenditure.getCreatedTime();
 	}
 }

--- a/src/main/java/com/budgetguard/domain/expenditure/entity/Expenditure.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/entity/Expenditure.java
@@ -1,0 +1,71 @@
+package com.budgetguard.domain.expenditure.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.budgetguard.domain.budget.entity.budgetcategory.BudgetCategory;
+import com.budgetguard.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Expenditure {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "expenditure_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "budget_category_id")
+	private BudgetCategory budgetCategory;
+
+	@Column(nullable = false)
+	private Integer amount;
+
+	@Column(nullable = false)
+	@CreatedDate
+	private LocalDateTime createdTime;
+
+	@Column(nullable = false)
+	private String memo;
+
+	// 지출 목록 조회 시, 합계 계산에서 제외 여부 (기본은 제외 안 함)
+	@Column(nullable = false)
+	@ColumnDefault("false")
+	private Boolean isExcluded;
+
+	@Builder
+	private Expenditure(Long id, Member member, BudgetCategory budgetCategory, Integer amount, LocalDateTime createdTime,
+		String memo, Boolean isExcluded) {
+		this.id = id;
+		this.member = member;
+		this.budgetCategory = budgetCategory;
+		this.amount = amount;
+		this.createdTime = createdTime;
+		this.memo = memo;
+		this.isExcluded = isExcluded;
+	}
+}

--- a/src/main/java/com/budgetguard/domain/expenditure/entity/Expenditure.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/entity/Expenditure.java
@@ -68,4 +68,21 @@ public class Expenditure {
 		this.memo = memo;
 		this.isExcluded = isExcluded;
 	}
+
+	/**
+	 * null 값이 아닌 속성을 수정한다.
+	 *
+	 * @param expenditure 수정할 지출 내용
+	 */
+	public void update(Expenditure expenditure) {
+		if (expenditure.getAmount() != null) {
+			this.amount = expenditure.getAmount();
+		}
+		if (expenditure.getMemo() != null) {
+			this.memo = expenditure.getMemo();
+		}
+		if (expenditure.getIsExcluded() != null) {
+			this.isExcluded = expenditure.getIsExcluded();
+		}
+	}
 }

--- a/src/main/java/com/budgetguard/global/config/jpa/JpaAuditingConfig.java
+++ b/src/main/java/com/budgetguard/global/config/jpa/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.budgetguard.global.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/budgetguard/global/error/ErrorCode.java
+++ b/src/main/java/com/budgetguard/global/error/ErrorCode.java
@@ -37,6 +37,9 @@ public enum ErrorCode {
 	// 예산
 	BUDGET_NOT_FOUND("존재하지 않는 예산입니다.", BAD_REQUEST),
 	BUDGET_CATEGORY_NOT_FOUND("존재하지 않는 예산 카테고리입니다.", BAD_REQUEST),
+
+	// 지출
+	EXPENDITURE_NOT_FOUND("존재하지 않는 지출입니다.", BAD_REQUEST),
 	;
 
 	private final String message;

--- a/src/main/java/com/budgetguard/global/error/ErrorCode.java
+++ b/src/main/java/com/budgetguard/global/error/ErrorCode.java
@@ -29,17 +29,17 @@ public enum ErrorCode {
 	// 인가 인증
 	ACCESS_DENIED("접근 권한이 없습니다.", FORBIDDEN),
 	UNAUTHORIZED_ENTRY_POINT("유효하지 않은 자격 증명입니다.", UNAUTHORIZED),
-	MEMBER_ACCOUNT_NOT_FOUND("존재하지 않는 계정입니다.", BAD_REQUEST),
+	MEMBER_ACCOUNT_NOT_FOUND("존재하지 않는 계정입니다.", NOT_FOUND),
 
 	// 사용자
-	MEMBER_NOT_FOUND("존재하지 않는 회원입니다.", BAD_REQUEST),
+	MEMBER_NOT_FOUND("존재하지 않는 회원입니다.", NOT_FOUND),
 
 	// 예산
-	BUDGET_NOT_FOUND("존재하지 않는 예산입니다.", BAD_REQUEST),
-	BUDGET_CATEGORY_NOT_FOUND("존재하지 않는 예산 카테고리입니다.", BAD_REQUEST),
+	BUDGET_NOT_FOUND("존재하지 않는 예산입니다.", NOT_FOUND),
+	BUDGET_CATEGORY_NOT_FOUND("존재하지 않는 예산 카테고리입니다.", NOT_FOUND),
 
 	// 지출
-	EXPENDITURE_NOT_FOUND("존재하지 않는 지출입니다.", BAD_REQUEST),
+	EXPENDITURE_NOT_FOUND("존재하지 않는 지출입니다.", NOT_FOUND),
 	;
 
 	private final String message;

--- a/src/test/java/com/budgetguard/domain/budget/api/BudgetControllerTest.java
+++ b/src/test/java/com/budgetguard/domain/budget/api/BudgetControllerTest.java
@@ -87,7 +87,7 @@ class BudgetControllerTest extends AbstractRestDocsTest {
 					.content(mapper.writeValueAsString(param))
 					.header(AUTHORIZATION, JWT_TOKEN)
 				)
-				.andExpect(status().isBadRequest());
+				.andExpect(status().isNotFound());
 		}
 
 		@Test
@@ -108,7 +108,7 @@ class BudgetControllerTest extends AbstractRestDocsTest {
 					.content(mapper.writeValueAsString(param))
 					.header(AUTHORIZATION, JWT_TOKEN)
 				)
-				.andExpect(status().isBadRequest());
+				.andExpect(status().isNotFound());
 		}
 	}
 

--- a/src/test/java/com/budgetguard/domain/budget/application/BudgetServiceTest.java
+++ b/src/test/java/com/budgetguard/domain/budget/application/BudgetServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.*;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ import com.budgetguard.global.error.BusinessException;
 @ExtendWith(MockitoExtension.class)
 class BudgetServiceTest {
 
-	static final Budget budget = BudgetTestHelper.createBudget();
+	static Budget budget;
 
 	@InjectMocks
 	BudgetService budgetService;
@@ -42,6 +43,11 @@ class BudgetServiceTest {
 
 	@Mock
 	BudgetCategoryRepository budgetCategoryRepository;
+
+	@BeforeEach
+	void setUp() {
+		budget = BudgetTestHelper.createBudget();
+	}
 
 	@Nested
 	@DisplayName("예산 설정")
@@ -104,18 +110,17 @@ class BudgetServiceTest {
 		@DisplayName("예산 수정 성공")
 		void 예산_수정_성공() {
 			int updatedAmount = 9000;
-			Budget newBudget = BudgetTestHelper.createBudget(); // 수정 시 다른 테스트에 영향을 끼치지 않도록 새로운 Budget 객체 생성
 			BudgetUpdateRequestParam param = BudgetUpdateRequestParam.builder()
-				.memberId(newBudget.getMember().getId())
+				.memberId(budget.getMember().getId())
 				.amount(updatedAmount)
 				.build();
 
-			given(budgetRepository.findById(any())).willReturn(Optional.of(newBudget));
-			given(memberRepository.findById(any())).willReturn(Optional.of(newBudget.getMember()));
+			given(budgetRepository.findById(any())).willReturn(Optional.of(budget));
+			given(memberRepository.findById(any())).willReturn(Optional.of(budget.getMember()));
 
-			budgetService.updateBudget(newBudget.getId(), param);
+			budgetService.updateBudget(budget.getId(), param);
 
-			assertThat(newBudget.getAmount()).isEqualTo(updatedAmount);
+			assertThat(budget.getAmount()).isEqualTo(updatedAmount);
 		}
 	}
 

--- a/src/test/java/com/budgetguard/domain/expenditure/ExpenditureTestHelper.java
+++ b/src/test/java/com/budgetguard/domain/expenditure/ExpenditureTestHelper.java
@@ -1,0 +1,25 @@
+package com.budgetguard.domain.expenditure;
+
+import static java.time.LocalDateTime.*;
+
+import com.budgetguard.domain.budget.BudgetCategoryTestHelper;
+import com.budgetguard.domain.expenditure.entity.Expenditure;
+import com.budgetguard.domain.member.MemberTestHelper;
+
+/**
+ * 테스트용 Expenditure 객체를 생성해주는 클래스
+ */
+public class ExpenditureTestHelper {
+
+	public static Expenditure createExpenditure() {
+		return Expenditure.builder()
+			.id(1L)
+			.member(MemberTestHelper.createMember())
+			.budgetCategory(BudgetCategoryTestHelper.createBudgetCategory())
+			.amount(10000)
+			.createdTime(now())
+			.memo("메모입니다.")
+			.isExcluded(false)
+			.build();
+	}
+}

--- a/src/test/java/com/budgetguard/domain/expenditure/api/ExpenditureControllerTest.java
+++ b/src/test/java/com/budgetguard/domain/expenditure/api/ExpenditureControllerTest.java
@@ -162,7 +162,38 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
 					.contentType(APPLICATION_JSON)
 					.header(HttpHeaders.AUTHORIZATION, JWT_TOKEN)
 				)
-				.andExpect(status().isBadRequest());
+				.andExpect(status().isNotFound());
+		}
+	}
+
+	@Nested
+	@DisplayName("지출 삭제")
+	class deleteExpenditure {
+		@Test
+		@DisplayName("지출 삭제 성공")
+		void 지출_삭제_성공() throws Exception {
+			given(expenditureService.getExpenditure(any())).willReturn(new ExpenditureDetailResponse(expenditure));
+			given(expenditureService.deleteExpenditure(any())).willReturn(expenditure.getId());
+
+			mockMvc.perform(delete(EXPENDITURE_URL + "/" + expenditure.getId())
+					.contentType(APPLICATION_JSON)
+					.header(HttpHeaders.AUTHORIZATION, JWT_TOKEN)
+				)
+				.andExpect(status().isOk());
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 지출을 삭제하면 실패")
+		void 존재하지_않는_지출을_삭제하면_실패() throws Exception {
+			int wrongExpenditureId = 100;
+			given(expenditureService.getExpenditure(any())).willReturn(new ExpenditureDetailResponse(expenditure));
+			given(expenditureService.deleteExpenditure(any())).willThrow(new BusinessException(wrongExpenditureId, "expenditureId", ErrorCode.EXPENDITURE_NOT_FOUND));
+
+			mockMvc.perform(delete(EXPENDITURE_URL + "/" + wrongExpenditureId)
+					.contentType(APPLICATION_JSON)
+					.header(HttpHeaders.AUTHORIZATION, JWT_TOKEN)
+				)
+				.andExpect(status().isNotFound());
 		}
 	}
 }

--- a/src/test/java/com/budgetguard/domain/expenditure/api/ExpenditureControllerTest.java
+++ b/src/test/java/com/budgetguard/domain/expenditure/api/ExpenditureControllerTest.java
@@ -1,0 +1,91 @@
+package com.budgetguard.domain.expenditure.api;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+
+import com.budgetguard.config.restdocs.AbstractRestDocsTest;
+import com.budgetguard.domain.auth.application.AuthService;
+import com.budgetguard.domain.expenditure.ExpenditureTestHelper;
+import com.budgetguard.domain.expenditure.application.ExpenditureService;
+import com.budgetguard.domain.expenditure.dto.ExpenditureCreateRequestParam;
+import com.budgetguard.domain.expenditure.entity.Expenditure;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(ExpenditureController.class)
+class ExpenditureControllerTest extends AbstractRestDocsTest {
+
+	static final String EXPENDITURE_URL = "/api/v1/expenditures";
+	static final String JWT_TOKEN = "JWT_TOKEN";
+
+	static Expenditure expenditure;
+
+	@MockBean
+	ExpenditureService expenditureService;
+
+	@MockBean
+	AuthService authService;
+
+	@Autowired
+	ObjectMapper mapper;
+
+	@BeforeEach
+	void setUp() {
+		expenditure = ExpenditureTestHelper.createExpenditure();
+	}
+
+	@Nested
+	@DisplayName("지출 생성")
+	class createExpenditure {
+		@Test
+		@DisplayName("지출 생성 성공")
+		void 지출_생성_성공() throws Exception {
+			ExpenditureCreateRequestParam param = ExpenditureCreateRequestParam.builder()
+				.memberId(expenditure.getMember().getId())
+				.categoryName(expenditure.getBudgetCategory().getName().name())
+				.amount(expenditure.getAmount())
+				.memo(expenditure.getMemo())
+				.isExcluded(expenditure.getIsExcluded())
+				.build();
+
+			given(expenditureService.createExpenditure(any())).willReturn(expenditure.getId());
+
+			mockMvc.perform(post(EXPENDITURE_URL)
+					.contentType(APPLICATION_JSON)
+					.content(mapper.writeValueAsString(param))
+					.header(HttpHeaders.AUTHORIZATION, JWT_TOKEN)
+				)
+				.andExpect(status().isOk());
+		}
+
+		@Test
+		@DisplayName("지출을 음수로 생성하면 실패")
+		void 지출을_음수로_생성하면_실패() throws Exception {
+			Integer wrongAmount = -1000;
+			ExpenditureCreateRequestParam param = ExpenditureCreateRequestParam.builder()
+				.memberId(expenditure.getMember().getId())
+				.categoryName(expenditure.getBudgetCategory().getName().name())
+				.amount(wrongAmount)
+				.memo(expenditure.getMemo())
+				.isExcluded(expenditure.getIsExcluded())
+				.build();
+
+			mockMvc.perform(post(EXPENDITURE_URL)
+					.contentType(APPLICATION_JSON)
+					.content(mapper.writeValueAsString(param))
+					.header(HttpHeaders.AUTHORIZATION, JWT_TOKEN)
+				)
+				.andExpect(status().isBadRequest());
+		}
+	}
+}

--- a/src/test/java/com/budgetguard/domain/expenditure/api/ExpenditureControllerTest.java
+++ b/src/test/java/com/budgetguard/domain/expenditure/api/ExpenditureControllerTest.java
@@ -19,6 +19,7 @@ import com.budgetguard.domain.auth.application.AuthService;
 import com.budgetguard.domain.expenditure.ExpenditureTestHelper;
 import com.budgetguard.domain.expenditure.application.ExpenditureService;
 import com.budgetguard.domain.expenditure.dto.ExpenditureCreateRequestParam;
+import com.budgetguard.domain.expenditure.dto.ExpenditureUpdateRequestParam;
 import com.budgetguard.domain.expenditure.entity.Expenditure;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -81,6 +82,49 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
 				.build();
 
 			mockMvc.perform(post(EXPENDITURE_URL)
+					.contentType(APPLICATION_JSON)
+					.content(mapper.writeValueAsString(param))
+					.header(HttpHeaders.AUTHORIZATION, JWT_TOKEN)
+				)
+				.andExpect(status().isBadRequest());
+		}
+	}
+
+	@Nested
+	@DisplayName("지출 수정")
+	class updateExpenditure {
+		@Test
+		@DisplayName("지출 수정 성공")
+		void 지출_수정_성공() throws Exception {
+			ExpenditureUpdateRequestParam param = ExpenditureUpdateRequestParam.builder()
+				.memberId(expenditure.getMember().getId())
+				.amount(expenditure.getAmount())
+				.memo(expenditure.getMemo())
+				.isExcluded(expenditure.getIsExcluded())
+				.build();
+
+			given(expenditureService.updateExpenditure(any(), any())).willReturn(expenditure.getId());
+
+			mockMvc.perform(put(EXPENDITURE_URL + "/" + expenditure.getId())
+					.contentType(APPLICATION_JSON)
+					.content(mapper.writeValueAsString(param))
+					.header(HttpHeaders.AUTHORIZATION, JWT_TOKEN)
+				)
+				.andExpect(status().isOk());
+		}
+
+		@Test
+		@DisplayName("지출을 음수로 수정하면 실패")
+		void 지출을_음수로_수정하면_실패() throws Exception {
+			Integer wrongAmount = -1000;
+			ExpenditureUpdateRequestParam param = ExpenditureUpdateRequestParam.builder()
+				.memberId(expenditure.getMember().getId())
+				.amount(wrongAmount)
+				.memo(expenditure.getMemo())
+				.isExcluded(expenditure.getIsExcluded())
+				.build();
+
+			mockMvc.perform(put(EXPENDITURE_URL + "/" + expenditure.getId())
 					.contentType(APPLICATION_JSON)
 					.content(mapper.writeValueAsString(param))
 					.header(HttpHeaders.AUTHORIZATION, JWT_TOKEN)

--- a/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
+++ b/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
@@ -18,6 +18,7 @@ import com.budgetguard.domain.budget.dao.budgetcategory.BudgetCategoryRepository
 import com.budgetguard.domain.expenditure.ExpenditureTestHelper;
 import com.budgetguard.domain.expenditure.dao.ExpenditureRepository;
 import com.budgetguard.domain.expenditure.dto.ExpenditureCreateRequestParam;
+import com.budgetguard.domain.expenditure.dto.ExpenditureUpdateRequestParam;
 import com.budgetguard.domain.expenditure.entity.Expenditure;
 import com.budgetguard.domain.member.dao.MemberRepository;
 
@@ -56,7 +57,6 @@ class ExpenditureServiceTest {
 				.memo(expenditure.getMemo())
 				.isExcluded(expenditure.getIsExcluded())
 				.build();
-
 			given(memberRepository.findById(anyLong())).willReturn(Optional.of(expenditure.getMember()));
 			given(budgetCategoryRepository.findByName(any())).willReturn(Optional.of(expenditure.getBudgetCategory()));
 			given(expenditureRepository.save(any())).willReturn(expenditure);
@@ -64,6 +64,29 @@ class ExpenditureServiceTest {
 			Long savedExpenditureId = expenditureService.createExpenditure(param);
 
 			assertThat(savedExpenditureId).isNotNull();
+		}
+	}
+
+	@Nested
+	@DisplayName("지출 수정")
+	class updateExpenditure {
+		@Test
+		@DisplayName("지출 수정 성공")
+		void 지출_수정_성공() {
+			ExpenditureUpdateRequestParam param = ExpenditureUpdateRequestParam.builder()
+				.memberId(expenditure.getMember().getId())
+				.amount(3000)
+				.memo("updated memo")
+				.isExcluded(true)
+				.build();
+			given(expenditureRepository.findById(anyLong())).willReturn(Optional.of(expenditure));
+
+			Long updatedExpenditureId = expenditureService.updateExpenditure(expenditure.getId(), param);
+
+			assertThat(updatedExpenditureId).isNotNull();
+			assertThat(expenditure.getAmount()).isEqualTo(3000);
+			assertThat(expenditure.getMemo()).isEqualTo("updated memo");
+			assertThat(expenditure.getIsExcluded()).isTrue();
 		}
 	}
 }

--- a/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
+++ b/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
@@ -17,8 +17,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.budgetguard.domain.budget.dao.budgetcategory.BudgetCategoryRepository;
 import com.budgetguard.domain.expenditure.ExpenditureTestHelper;
 import com.budgetguard.domain.expenditure.dao.ExpenditureRepository;
-import com.budgetguard.domain.expenditure.dto.ExpenditureCreateRequestParam;
-import com.budgetguard.domain.expenditure.dto.ExpenditureUpdateRequestParam;
+import com.budgetguard.domain.expenditure.dto.request.ExpenditureCreateRequestParam;
+import com.budgetguard.domain.expenditure.dto.request.ExpenditureUpdateRequestParam;
+import com.budgetguard.domain.expenditure.dto.response.ExpenditureDetailResponse;
 import com.budgetguard.domain.expenditure.entity.Expenditure;
 import com.budgetguard.domain.member.dao.MemberRepository;
 
@@ -80,6 +81,7 @@ class ExpenditureServiceTest {
 				.isExcluded(true)
 				.build();
 			given(expenditureRepository.findById(anyLong())).willReturn(Optional.of(expenditure));
+			given(memberRepository.findById(anyLong())).willReturn(Optional.of(expenditure.getMember()));
 
 			Long updatedExpenditureId = expenditureService.updateExpenditure(expenditure.getId(), param);
 
@@ -87,6 +89,20 @@ class ExpenditureServiceTest {
 			assertThat(expenditure.getAmount()).isEqualTo(3000);
 			assertThat(expenditure.getMemo()).isEqualTo("updated memo");
 			assertThat(expenditure.getIsExcluded()).isTrue();
+		}
+	}
+
+	@Nested
+	@DisplayName("지출 상세 조회")
+	class getExpenditure {
+		@Test
+		@DisplayName("지출 상세 조회 성공")
+		void 지출_상세_조회_성공() {
+			given(expenditureRepository.findById(anyLong())).willReturn(Optional.of(expenditure));
+
+			ExpenditureDetailResponse expenditureDetail = expenditureService.getExpenditure(expenditure.getId());
+
+			assertThat(expenditureDetail).isNotNull();
 		}
 	}
 }

--- a/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
+++ b/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
@@ -105,4 +105,18 @@ class ExpenditureServiceTest {
 			assertThat(expenditureDetail).isNotNull();
 		}
 	}
+
+	@Nested
+	@DisplayName("지출 삭제")
+	class deleteExpenditure {
+		@Test
+		@DisplayName("지출 삭제 성공")
+		void 지출_삭제_성공() {
+			given(expenditureRepository.findById(anyLong())).willReturn(Optional.of(expenditure));
+
+			Long deletedExpenditureId = expenditureService.deleteExpenditure(expenditure.getId());
+
+			assertThat(deletedExpenditureId).isNotNull();
+		}
+	}
 }

--- a/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
+++ b/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
@@ -3,6 +3,8 @@ package com.budgetguard.domain.expenditure.application;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -14,12 +16,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.budgetguard.domain.budget.constant.CategoryName;
 import com.budgetguard.domain.budget.dao.budgetcategory.BudgetCategoryRepository;
 import com.budgetguard.domain.expenditure.ExpenditureTestHelper;
 import com.budgetguard.domain.expenditure.dao.ExpenditureRepository;
 import com.budgetguard.domain.expenditure.dto.request.ExpenditureCreateRequestParam;
+import com.budgetguard.domain.expenditure.dto.request.ExpenditureSearchCond;
 import com.budgetguard.domain.expenditure.dto.request.ExpenditureUpdateRequestParam;
 import com.budgetguard.domain.expenditure.dto.response.ExpenditureDetailResponse;
+import com.budgetguard.domain.expenditure.dto.response.ExpenditureSearchResponse;
 import com.budgetguard.domain.expenditure.entity.Expenditure;
 import com.budgetguard.domain.member.dao.MemberRepository;
 
@@ -117,6 +122,28 @@ class ExpenditureServiceTest {
 			Long deletedExpenditureId = expenditureService.deleteExpenditure(expenditure.getId());
 
 			assertThat(deletedExpenditureId).isNotNull();
+		}
+	}
+
+	@Nested
+	@DisplayName("지출 검색 목록 조회")
+	class getExpenditures {
+		@Test
+		@DisplayName("지출 검색 목록 조회 성공")
+		void 지출_검색_목록_조회_성공() {
+			ExpenditureSearchCond searchCond = ExpenditureSearchCond.builder()
+				.memberId(expenditure.getMember().getId())
+				.startDate(LocalDate.of(2021, 1, 1))
+				.endDate(LocalDate.of(2021, 1, 31))
+				.categoryName(CategoryName.FOOD.name())
+				.minAmount(1000)
+				.maxAmount(5000)
+				.build();
+			given(expenditureRepository.searchExpenditures(any())).willReturn(List.of(expenditure));
+
+			ExpenditureSearchResponse searchResponse = expenditureService.searchExpenditures(searchCond);
+
+			assertThat(searchResponse).isNotNull();
 		}
 	}
 }

--- a/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
+++ b/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
@@ -1,0 +1,69 @@
+package com.budgetguard.domain.expenditure.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.budgetguard.domain.budget.dao.budgetcategory.BudgetCategoryRepository;
+import com.budgetguard.domain.expenditure.ExpenditureTestHelper;
+import com.budgetguard.domain.expenditure.dao.ExpenditureRepository;
+import com.budgetguard.domain.expenditure.dto.ExpenditureCreateRequestParam;
+import com.budgetguard.domain.expenditure.entity.Expenditure;
+import com.budgetguard.domain.member.dao.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ExpenditureServiceTest {
+
+	static Expenditure expenditure;
+
+	@InjectMocks
+	ExpenditureService expenditureService;
+
+	@Mock
+	ExpenditureRepository expenditureRepository;
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@Mock
+	BudgetCategoryRepository budgetCategoryRepository;
+
+	@BeforeEach
+	void setUp() {
+		expenditure = ExpenditureTestHelper.createExpenditure();
+	}
+
+	@Nested
+	@DisplayName("지출 생성")
+	class createExpenditure {
+		@Test
+		@DisplayName("지출 생성 성공")
+		void 지출_생성_성공() {
+			ExpenditureCreateRequestParam param = ExpenditureCreateRequestParam.builder()
+				.memberId(expenditure.getMember().getId())
+				.categoryName(expenditure.getBudgetCategory().getName().name())
+				.amount(expenditure.getAmount())
+				.memo(expenditure.getMemo())
+				.isExcluded(expenditure.getIsExcluded())
+				.build();
+
+			given(memberRepository.findById(anyLong())).willReturn(Optional.of(expenditure.getMember()));
+			given(budgetCategoryRepository.findByName(any())).willReturn(Optional.of(expenditure.getBudgetCategory()));
+			given(expenditureRepository.save(any())).willReturn(expenditure);
+
+			Long savedExpenditureId = expenditureService.createExpenditure(param);
+
+			assertThat(savedExpenditureId).isNotNull();
+		}
+	}
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #13 

## 📝 Description

지출 도메인 및 CRUD 기능을 구현했습니다.

모든 기능에 JWT 토큰 인증을 필요로 하도록 설계했습니다.

쿼리 파라미터로 받는 검색 조건 중 사용자 ID와 조회 시작일, 조회 종료일은 필수입니다.
그밖의 카테고리, 최소 금액, 최대 금액은 선택 사항이며 없을 경우 해당 조건은 무시됩니다.


## ⭐️ Review

향후 Querydsl 리포지토리 테스트를 작성할 필요가 있어 보입니다.
