### PR TITLE
feat: 지난 요일 대비 지출 통계 생성

### DIFF
--- a/src/docs/asciidoc/expenditure.adoc
+++ b/src/docs/asciidoc/expenditure.adoc
@@ -111,3 +111,16 @@ Response
 - 200 OK
 
 include::{snippets}/create-expenditure-rate/지난_달_대비_통계_생성_성공/http-response.adoc[]
+
+
+== 지난 요일 대비 지출 통계
+
+Request
+
+include::{snippets}/create-expenditure-rate/지난_요일_대비_통계_생성_성공/http-request.adoc[]
+
+Response
+
+- 200 OK
+
+include::{snippets}/create-expenditure-rate/지난_요일_대비_통계_생성_성공/http-response.adoc[]

--- a/src/main/java/com/budgetguard/domain/expenditure/api/ExpenditureController.java
+++ b/src/main/java/com/budgetguard/domain/expenditure/api/ExpenditureController.java
@@ -195,7 +195,26 @@ public class ExpenditureController {
 		String account = tokenManager.getAccountFromToken(token);
 
 		// 월별 지출 비율 정보를 생성한다.
-		ExpenditureRateResponse expenditureRate = expenditureService.createExpenditureRate(account);
+		ExpenditureRateResponse expenditureRate = expenditureService.createExpenditureMonthlyRate(account);
+
+		return ResponseEntity.ok(ApiResponse.toSuccessForm(expenditureRate));
+	}
+
+	/**
+	 * 지난 요일 대비 총액, 카테고리 별 소비율을 생성한다.
+	 *
+	 * @param token JWT 토큰
+	 * @return 지난 요일 대비 소비율
+	 */
+	@GetMapping("/day-of-week-rate")
+	public ResponseEntity<ApiResponse> createExpenditureDayOfWeekRate(
+		@RequestHeader(AUTHORIZATION) String token
+	) {
+		// 토큰에서 사용자 계정명을 추출한다.
+		String account = tokenManager.getAccountFromToken(token);
+
+		// 요일별 지출 비율 정보를 생성한다.
+		ExpenditureRateResponse expenditureRate = expenditureService.createExpenditureDayOfWeekRate(account);
 
 		return ResponseEntity.ok(ApiResponse.toSuccessForm(expenditureRate));
 	}

--- a/src/test/java/com/budgetguard/domain/expenditure/api/ExpenditureControllerTest.java
+++ b/src/test/java/com/budgetguard/domain/expenditure/api/ExpenditureControllerTest.java
@@ -326,9 +326,30 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
 				))
 				.build();
 			given(tokenManager.getAccountFromToken(any())).willReturn("account");
-			given(expenditureService.createExpenditureRate(any())).willReturn(expenditureRate);
+			given(expenditureService.createExpenditureMonthlyRate(any())).willReturn(expenditureRate);
 
 			mockMvc.perform(get(EXPENDITURE_URL + "/monthly-rate")
+					.contentType(APPLICATION_JSON)
+					.header(HttpHeaders.AUTHORIZATION, JWT_TOKEN)
+				)
+				.andExpect(status().isOk());
+		}
+
+		@Test
+		@DisplayName("지난 요일 대비 통계 생성 성공")
+		void 지난_요일_대비_통계_생성_성공() throws Exception {
+			ExpenditureRateResponse expenditureRate = ExpenditureRateResponse.builder()
+				.totalRate(120)
+				.ratePerCategory(Map.of(
+					CategoryName.FOOD, 160,
+					CategoryName.TRANSPORTATION, 70,
+					CategoryName.ENTERTAINMENT, 60
+				))
+				.build();
+			given(tokenManager.getAccountFromToken(any())).willReturn("account");
+			given(expenditureService.createExpenditureDayOfWeekRate(any())).willReturn(expenditureRate);
+
+			mockMvc.perform(get(EXPENDITURE_URL + "/day-of-week-rate")
 					.contentType(APPLICATION_JSON)
 					.header(HttpHeaders.AUTHORIZATION, JWT_TOKEN)
 				)

--- a/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
+++ b/src/test/java/com/budgetguard/domain/expenditure/application/ExpenditureServiceTest.java
@@ -2,13 +2,9 @@ package com.budgetguard.domain.expenditure.application;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.http.MediaType.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpHeaders;
 
 import com.budgetguard.domain.budget.BudgetTestHelper;
 import com.budgetguard.domain.budget.constant.CategoryName;
@@ -202,7 +197,19 @@ class ExpenditureServiceTest {
 			given(memberRepository.findByAccount(any())).willReturn(Optional.of(expenditure.getMember()));
 			given(expenditureRepository.findAllByMemberId(any())).willReturn(List.of(expenditure));
 
-			ExpenditureRateResponse expenditureRate = expenditureService.createExpenditureRate(
+			ExpenditureRateResponse expenditureRate = expenditureService.createExpenditureMonthlyRate(
+				expenditure.getMember().getAccount());
+
+			assertThat(expenditureRate).isNotNull();
+		}
+
+		@Test
+		@DisplayName("지난 요일 대비 통계 생성 성공")
+		void 지난_요일_대비_통계_생성_성공() {
+			given(memberRepository.findByAccount(any())).willReturn(Optional.of(expenditure.getMember()));
+			given(expenditureRepository.findAllByMemberId(any())).willReturn(List.of(expenditure));
+
+			ExpenditureRateResponse expenditureRate = expenditureService.createExpenditureDayOfWeekRate(
 				expenditure.getMember().getAccount());
 
 			assertThat(expenditureRate).isNotNull();


### PR DESCRIPTION
## 🔥 Related Issue

close: #21 

## 📝 Description

오늘이 월요일이라면 지난 월요일까지의 소비율의 차이를 보여주는 기능을 구현했습니다.
